### PR TITLE
Add Pagination and Total Absence Count

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A Flutter application to manage and display employee absences. It includes featu
 
 ### Core Requirements
 - [x] Display a list of absences including employee names
-- [ ] Show the first 10 absences with pagination
+- [x] Show the first 10 absences with pagination
 - [ ] Display the total number of absences
 - [x] Add unit tests for data, domain, UI, and utility layers
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A Flutter application to manage and display employee absences. It includes featu
 ### Core Requirements
 - [x] Display a list of absences including employee names
 - [x] Show the first 10 absences with pagination
-- [ ] Display the total number of absences
+- [x] Display the total number of absences
 - [x] Add unit tests for data, domain, UI, and utility layers
 
 #### For each absence, display:

--- a/lib/data/repositories/absence/absence_repository.dart
+++ b/lib/data/repositories/absence/absence_repository.dart
@@ -1,5 +1,5 @@
-import 'package:absence_manager/domain/models/absence/absence.dart';
+import 'package:absence_manager/domain/models/absence/absence_list.dart';
 
 abstract class AbsenceRepository {
-  Future<List<Absence>> getAllAbsences({required int offset, required int limit});
+  Future<AbsenceList> getAllAbsences({required int offset, required int limit});
 }

--- a/lib/data/repositories/absence/absence_repository.dart
+++ b/lib/data/repositories/absence/absence_repository.dart
@@ -1,5 +1,5 @@
 import 'package:absence_manager/domain/models/absence/absence.dart';
 
 abstract class AbsenceRepository {
-  Future<List<Absence>> getAllAbsences();
+  Future<List<Absence>> getAllAbsences({required int offset, required int limit});
 }

--- a/lib/data/repositories/absence/absence_repository_local.dart
+++ b/lib/data/repositories/absence/absence_repository_local.dart
@@ -8,30 +8,30 @@ class AbsenceLocalRepository implements AbsenceRepository {
   AbsenceLocalRepository(this.service);
 
   @override
-  Future<List<Absence>> getAllAbsences() async {
+  Future<List<Absence>> getAllAbsences({int offset = 0, int limit = 10}) async {
     final apiAbsences = await service.fetchAbsences();
-    return apiAbsences.map((dto) {
-      // Determine status based on timestamps:
-      // If confirmedAt is present → Confirmed
-      // Else if rejectedAt is present → Rejected
-      // Otherwise → Requested
-      final status =
-          dto.confirmedAt != null
-              ? AbsenceStatus.confirmed
-              : dto.rejectedAt != null
-              ? AbsenceStatus.rejected
-              : AbsenceStatus.requested;
+    return apiAbsences
+        .map((dto) {
+          final status =
+              dto.confirmedAt != null
+                  ? AbsenceStatus.confirmed
+                  : dto.rejectedAt != null
+                  ? AbsenceStatus.rejected
+                  : AbsenceStatus.requested;
 
-      return Absence(
-        id: dto.id ?? -1,
-        userId: dto.userId ?? -1,
-        type: dto.type ?? '',
-        startDate: DateTime.tryParse(dto.startDate ?? '') ?? DateTime(1970),
-        endDate: DateTime.tryParse(dto.endDate ?? '') ?? DateTime(1970),
-        memberNote: dto.memberNote?.trim().isEmpty ?? true ? null : dto.memberNote,
-        admitterNote: dto.admitterNote?.trim().isEmpty ?? true ? null : dto.admitterNote,
-        status: status,
-      );
-    }).toList();
+          return Absence(
+            id: dto.id ?? -1,
+            userId: dto.userId ?? -1,
+            type: dto.type ?? '',
+            startDate: DateTime.tryParse(dto.startDate ?? '') ?? DateTime(1970),
+            endDate: DateTime.tryParse(dto.endDate ?? '') ?? DateTime(1970),
+            memberNote: dto.memberNote?.trim().isEmpty ?? true ? null : dto.memberNote,
+            admitterNote: dto.admitterNote?.trim().isEmpty ?? true ? null : dto.admitterNote,
+            status: status,
+          );
+        })
+        .skip(offset)
+        .take(limit)
+        .toList();
   }
 }

--- a/lib/data/repositories/absence/absence_repository_local.dart
+++ b/lib/data/repositories/absence/absence_repository_local.dart
@@ -1,6 +1,7 @@
 import 'package:absence_manager/data/repositories/absence/absence_repository.dart';
 import 'package:absence_manager/data/services/local/local_absence_service.dart';
 import 'package:absence_manager/domain/models/absence/absence.dart';
+import 'package:absence_manager/domain/models/absence/absence_list.dart';
 
 class AbsenceLocalRepository implements AbsenceRepository {
   final LocalAbsenceService service;
@@ -8,30 +9,35 @@ class AbsenceLocalRepository implements AbsenceRepository {
   AbsenceLocalRepository(this.service);
 
   @override
-  Future<List<Absence>> getAllAbsences({int offset = 0, int limit = 10}) async {
+  Future<AbsenceList> getAllAbsences({int offset = 0, int limit = 10}) async {
     final apiAbsences = await service.fetchAbsences();
-    return apiAbsences
-        .map((dto) {
-          final status =
-              dto.confirmedAt != null
-                  ? AbsenceStatus.confirmed
-                  : dto.rejectedAt != null
-                  ? AbsenceStatus.rejected
-                  : AbsenceStatus.requested;
+    final totalCount = apiAbsences.length;
 
-          return Absence(
-            id: dto.id ?? -1,
-            userId: dto.userId ?? -1,
-            type: dto.type ?? '',
-            startDate: DateTime.tryParse(dto.startDate ?? '') ?? DateTime(1970),
-            endDate: DateTime.tryParse(dto.endDate ?? '') ?? DateTime(1970),
-            memberNote: dto.memberNote?.trim().isEmpty ?? true ? null : dto.memberNote,
-            admitterNote: dto.admitterNote?.trim().isEmpty ?? true ? null : dto.admitterNote,
-            status: status,
-          );
-        })
-        .skip(offset)
-        .take(limit)
-        .toList();
+    final absences =
+        apiAbsences
+            .map((dto) {
+              final status =
+                  dto.confirmedAt != null
+                      ? AbsenceStatus.confirmed
+                      : dto.rejectedAt != null
+                      ? AbsenceStatus.rejected
+                      : AbsenceStatus.requested;
+
+              return Absence(
+                id: dto.id ?? -1,
+                userId: dto.userId ?? -1,
+                type: dto.type ?? '',
+                startDate: DateTime.tryParse(dto.startDate ?? '') ?? DateTime(1970),
+                endDate: DateTime.tryParse(dto.endDate ?? '') ?? DateTime(1970),
+                memberNote: dto.memberNote?.trim().isEmpty ?? true ? null : dto.memberNote,
+                admitterNote: dto.admitterNote?.trim().isEmpty ?? true ? null : dto.admitterNote,
+                status: status,
+              );
+            })
+            .skip(offset)
+            .take(limit)
+            .toList();
+
+    return AbsenceList(totalCount: totalCount, absences: absences);
   }
 }

--- a/lib/domain/models/absence/absence_list.dart
+++ b/lib/domain/models/absence/absence_list.dart
@@ -1,0 +1,8 @@
+import 'package:absence_manager/domain/models/absence/absence.dart';
+
+class AbsenceList {
+  final int totalCount;
+  final List<Absence> absences;
+
+  AbsenceList({required this.totalCount, required this.absences});
+}

--- a/lib/domain/models/absence_list_with_members.dart
+++ b/lib/domain/models/absence_list_with_members.dart
@@ -1,0 +1,8 @@
+import 'package:absence_manager/domain/models/absence_with_member.dart';
+
+class AbsenceListWithMembers {
+  final int totalCount;
+  final List<AbsenceWithMember> absences;
+
+  AbsenceListWithMembers({required this.totalCount, required this.absences});
+}

--- a/lib/domain/use_cases/get_absences_with_members_use_case.dart
+++ b/lib/domain/use_cases/get_absences_with_members_use_case.dart
@@ -18,21 +18,18 @@ class GetAbsencesWithMembersUseCase {
 
   GetAbsencesWithMembersUseCase(this.absenceRepo, this.memberRepo);
 
-  Future<List<AbsenceWithMember>> execute() async {
-    final absences = await absenceRepo.getAllAbsences();
+  Future<List<AbsenceWithMember>> execute({int offset = 0, int limit = 10}) async {
+    final absences = await absenceRepo.getAllAbsences(offset: offset, limit: limit);
     final members = await memberRepo.getAllMembers();
 
+    // Create a map of userId to Member for quick lookup
     final memberMap = {for (var m in members) m.userId: m};
 
+    // Combine absences with corresponding members
     return absences.map((absence) {
       final member =
           memberMap[absence.userId] ??
-          Member(
-            userId: absence.userId,
-            name: "Unknown",
-            imageUrl: "", // or a placeholder image
-          );
-
+          Member(userId: absence.userId, name: "Unknown", imageUrl: "");
       return AbsenceWithMember(absence: absence, member: member);
     }).toList();
   }

--- a/lib/domain/use_cases/get_absences_with_members_use_case.dart
+++ b/lib/domain/use_cases/get_absences_with_members_use_case.dart
@@ -1,5 +1,6 @@
 import 'package:absence_manager/data/repositories/absence/absence_repository.dart';
 import 'package:absence_manager/data/repositories/member/member_repository.dart';
+import 'package:absence_manager/domain/models/absence_list_with_members.dart';
 import 'package:absence_manager/domain/models/absence_with_member.dart';
 import 'package:absence_manager/domain/models/member/member.dart';
 
@@ -18,19 +19,26 @@ class GetAbsencesWithMembersUseCase {
 
   GetAbsencesWithMembersUseCase(this.absenceRepo, this.memberRepo);
 
-  Future<List<AbsenceWithMember>> execute({int offset = 0, int limit = 10}) async {
-    final absences = await absenceRepo.getAllAbsences(offset: offset, limit: limit);
+  Future<AbsenceListWithMembers> execute({int offset = 0, int limit = 10}) async {
+    final absenceList = await absenceRepo.getAllAbsences(offset: offset, limit: limit);
     final members = await memberRepo.getAllMembers();
 
     // Create a map of userId to Member for quick lookup
     final memberMap = {for (var m in members) m.userId: m};
 
     // Combine absences with corresponding members
-    return absences.map((absence) {
-      final member =
-          memberMap[absence.userId] ??
-          Member(userId: absence.userId, name: "Unknown", imageUrl: "");
-      return AbsenceWithMember(absence: absence, member: member);
-    }).toList();
+    final absencesWithMembers =
+        absenceList.absences.map((absence) {
+          final member =
+              memberMap[absence.userId] ??
+              Member(userId: absence.userId, name: "Unknown", imageUrl: "");
+          return AbsenceWithMember(absence: absence, member: member);
+        }).toList();
+
+    // Return totalCount and combined absences
+    return AbsenceListWithMembers(
+      totalCount: absenceList.totalCount,
+      absences: absencesWithMembers,
+    );
   }
 }

--- a/lib/ui/absence/bloc/absence_bloc.dart
+++ b/lib/ui/absence/bloc/absence_bloc.dart
@@ -11,8 +11,14 @@ class AbsencesBloc extends Bloc<AbsencesEvent, AbsencesState> {
     on<LoadAbsences>((event, emit) async {
       emit(AbsencesLoading());
       try {
-        final absences = await useCase.execute(offset: 0, limit: 10);
-        emit(AbsencesLoaded(absences, hasMore: absences.length == 10));
+        final result = await useCase.execute(offset: 0, limit: 10);
+        emit(
+          AbsencesLoaded(
+            absences: result.absences,
+            hasMore: result.absences.length == 10,
+            totalCount: result.totalCount,
+          ),
+        );
       } catch (e) {
         emit(AbsencesError(e.toString()));
       }
@@ -24,12 +30,15 @@ class AbsencesBloc extends Bloc<AbsencesEvent, AbsencesState> {
       if (currentState is AbsencesLoaded) {
         emit(AbsencesLoadingMore());
         try {
-          final additionalAbsences = await useCase.execute(
-            offset: event.offset,
-            limit: event.limit,
+          final result = await useCase.execute(offset: event.offset, limit: event.limit);
+          final hasMore = result.absences.length == event.limit;
+          emit(
+            AbsencesLoaded(
+              absences: currentState.absences + result.absences,
+              hasMore: hasMore,
+              totalCount: result.totalCount,
+            ),
           );
-          final hasMore = additionalAbsences.length == event.limit;
-          emit(AbsencesLoaded(currentState.absences + additionalAbsences, hasMore: hasMore));
         } catch (e) {
           emit(AbsencesError(e.toString()));
         }

--- a/lib/ui/absence/bloc/absence_event.dart
+++ b/lib/ui/absence/bloc/absence_event.dart
@@ -6,3 +6,13 @@ abstract class AbsencesEvent extends Equatable {
 }
 
 class LoadAbsences extends AbsencesEvent {}
+
+class LoadMoreAbsences extends AbsencesEvent {
+  final int offset;
+  final int limit;
+
+  LoadMoreAbsences({required this.offset, required this.limit});
+
+  @override
+  List<Object?> get props => [offset, limit];
+}

--- a/lib/ui/absence/bloc/absence_state.dart
+++ b/lib/ui/absence/bloc/absence_state.dart
@@ -15,11 +15,12 @@ class AbsencesLoadingMore extends AbsencesState {}
 class AbsencesLoaded extends AbsencesState {
   final List<AbsenceWithMember> absences;
   final bool hasMore;
+  final int totalCount;
 
-  AbsencesLoaded(this.absences, {this.hasMore = false});
+  AbsencesLoaded({required this.absences, required this.hasMore, required this.totalCount});
 
   @override
-  List<Object?> get props => [absences, hasMore];
+  List<Object?> get props => [absences, hasMore, totalCount];
 }
 
 class AbsencesError extends AbsencesState {

--- a/lib/ui/absence/bloc/absence_state.dart
+++ b/lib/ui/absence/bloc/absence_state.dart
@@ -10,13 +10,16 @@ class AbsencesInitial extends AbsencesState {}
 
 class AbsencesLoading extends AbsencesState {}
 
+class AbsencesLoadingMore extends AbsencesState {}
+
 class AbsencesLoaded extends AbsencesState {
   final List<AbsenceWithMember> absences;
+  final bool hasMore;
 
-  AbsencesLoaded(this.absences);
+  AbsencesLoaded(this.absences, {this.hasMore = false});
 
   @override
-  List<Object?> get props => [absences];
+  List<Object?> get props => [absences, hasMore];
 }
 
 class AbsencesError extends AbsencesState {

--- a/lib/ui/absence/widgets/absence_screen.dart
+++ b/lib/ui/absence/widgets/absence_screen.dart
@@ -2,6 +2,7 @@ import 'package:absence_manager/ui/absence/bloc/absence_bloc.dart';
 import 'package:absence_manager/ui/absence/bloc/absence_event.dart';
 import 'package:absence_manager/ui/absence/bloc/absence_state.dart';
 import 'package:absence_manager/ui/absence/widgets/absences_list.dart';
+import 'package:absence_manager/ui/absence/widgets/absences_summary.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -22,16 +23,27 @@ class AbsencesScreen extends StatelessWidget {
               child: Center(child: Text("Error: ${state.message}", textAlign: TextAlign.center)),
             );
           } else if (state is AbsencesLoaded) {
-            return AbsencesList(
-              absenceWithMember: state.absences,
-              hasMore: state.hasMore,
-              onLoadMore: () {
-                if (state.hasMore) {
-                  context.read<AbsencesBloc>().add(
-                    LoadMoreAbsences(offset: state.absences.length, limit: 10),
-                  );
-                }
-              },
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                AbsencesSummary(
+                  totalAbsences: state.totalCount,
+                  fetchedAbsences: state.absences.length,
+                ),
+                Expanded(
+                  child: AbsencesList(
+                    absenceWithMember: state.absences,
+                    hasMore: state.hasMore,
+                    onLoadMore: () {
+                      if (state.hasMore) {
+                        context.read<AbsencesBloc>().add(
+                          LoadMoreAbsences(offset: state.absences.length, limit: 10),
+                        );
+                      }
+                    },
+                  ),
+                ),
+              ],
             );
           }
           return Center(child: Text("No data"));

--- a/lib/ui/absence/widgets/absence_screen.dart
+++ b/lib/ui/absence/widgets/absence_screen.dart
@@ -1,6 +1,7 @@
 import 'package:absence_manager/ui/absence/bloc/absence_bloc.dart';
+import 'package:absence_manager/ui/absence/bloc/absence_event.dart';
 import 'package:absence_manager/ui/absence/bloc/absence_state.dart';
-import 'package:absence_manager/ui/absence/widgets/absence_tile.dart';
+import 'package:absence_manager/ui/absence/widgets/absences_list.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -10,29 +11,30 @@ class AbsencesScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text("Absences")),
+      appBar: AppBar(title: Text("Absences")),
       body: BlocBuilder<AbsencesBloc, AbsencesState>(
         builder: (context, state) {
           if (state is AbsencesLoading) {
-            return const Center(child: CircularProgressIndicator());
-          } else if (state is AbsencesLoaded) {
-            if (state.absences.isEmpty) {
-              return const Center(child: Text("No absences found."));
-            }
-            return ListView.builder(
-              itemCount: state.absences.length,
-              itemBuilder: (context, index) {
-                final absenceWithMember = state.absences[index];
-                return AbsenceTile(data: absenceWithMember);
-              },
-            );
+            return Center(child: CircularProgressIndicator());
           } else if (state is AbsencesError) {
             return Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: Center(child: Text("Error: ${state.message}", textAlign: TextAlign.center)),
             );
+          } else if (state is AbsencesLoaded) {
+            return AbsencesList(
+              absenceWithMember: state.absences,
+              hasMore: state.hasMore,
+              onLoadMore: () {
+                if (state.hasMore) {
+                  context.read<AbsencesBloc>().add(
+                    LoadMoreAbsences(offset: state.absences.length, limit: 10),
+                  );
+                }
+              },
+            );
           }
-          return const SizedBox.shrink(); // AbsencesInitial
+          return Center(child: Text("No data"));
         },
       ),
     );

--- a/lib/ui/absence/widgets/absences_list.dart
+++ b/lib/ui/absence/widgets/absences_list.dart
@@ -21,7 +21,12 @@ class AbsencesList extends StatelessWidget {
       itemBuilder: (context, index) {
         if (index == absenceWithMember.length && hasMore) {
           // Load More Button
-          return Center(child: ElevatedButton(onPressed: onLoadMore, child: Text("Load More")));
+          return SafeArea(
+            child: Container(
+              margin: EdgeInsets.only(top: 16),
+              child: Center(child: ElevatedButton(onPressed: onLoadMore, child: Text("Load More"))),
+            ),
+          );
         }
 
         return AbsenceTile(data: absenceWithMember[index]);

--- a/lib/ui/absence/widgets/absences_list.dart
+++ b/lib/ui/absence/widgets/absences_list.dart
@@ -1,0 +1,31 @@
+import 'package:absence_manager/domain/models/absence_with_member.dart';
+import 'package:absence_manager/ui/absence/widgets/absence_tile.dart';
+import 'package:flutter/material.dart';
+
+class AbsencesList extends StatelessWidget {
+  final List<AbsenceWithMember> absenceWithMember;
+  final bool hasMore;
+  final VoidCallback onLoadMore;
+
+  const AbsencesList({
+    super.key,
+    required this.absenceWithMember,
+    required this.hasMore,
+    required this.onLoadMore,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      itemCount: absenceWithMember.length + (hasMore ? 1 : 0),
+      itemBuilder: (context, index) {
+        if (index == absenceWithMember.length && hasMore) {
+          // Load More Button
+          return Center(child: ElevatedButton(onPressed: onLoadMore, child: Text("Load More")));
+        }
+
+        return AbsenceTile(data: absenceWithMember[index]);
+      },
+    );
+  }
+}

--- a/lib/ui/absence/widgets/absences_summary.dart
+++ b/lib/ui/absence/widgets/absences_summary.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+
+class AbsencesSummary extends StatelessWidget {
+  final int totalAbsences;
+  final int fetchedAbsences;
+
+  const AbsencesSummary({super.key, required this.totalAbsences, required this.fetchedAbsences});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Card(
+        elevation: 3,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text("Total Absences", style: TextStyle(fontSize: 14, color: Colors.grey[700])),
+                  Text(
+                    "$totalAbsences",
+                    style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+                  ),
+                ],
+              ),
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text("Fetched", style: TextStyle(fontSize: 14, color: Colors.grey[700])),
+                  Text(
+                    "$fetchedAbsences",
+                    style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/data/repositories/absence/absence_local_repository_test.dart
+++ b/test/data/repositories/absence/absence_local_repository_test.dart
@@ -44,9 +44,10 @@ void main() {
       final result = await repository.getAllAbsences(offset: 10, limit: 5);
 
       // Assert
-      expect(result, hasLength(5));
-      expect(result.first.id, 10);
-      expect(result.last.id, 14);
+      expect(result.totalCount, 20);
+      expect(result.absences, hasLength(5));
+      expect(result.absences.first.id, 10);
+      expect(result.absences.last.id, 14);
     });
 
     test('returns an empty list when offset exceeds data length', () async {
@@ -75,7 +76,8 @@ void main() {
       final result = await repository.getAllAbsences(offset: 20, limit: 5);
 
       // Assert
-      expect(result, isEmpty);
+      expect(result.totalCount, 10);
+      expect(result.absences, isEmpty);
     });
 
     test('returns the first 10 absences by default', () async {
@@ -104,9 +106,10 @@ void main() {
       final result = await repository.getAllAbsences();
 
       // Assert
-      expect(result, hasLength(10));
-      expect(result.first.id, 0);
-      expect(result.last.id, 9);
+      expect(result.totalCount, 15);
+      expect(result.absences, hasLength(10));
+      expect(result.absences.first.id, 0);
+      expect(result.absences.last.id, 9);
     });
 
     test('handles null fields gracefully with pagination', () async {
@@ -132,8 +135,9 @@ void main() {
       final result = await repository.getAllAbsences(offset: 0, limit: 1);
 
       // Assert
-      expect(result.length, 1);
-      final absence = result.first;
+      expect(result.totalCount, 1);
+      expect(result.absences, hasLength(1));
+      final absence = result.absences.first;
       expect(absence.startDate, DateTime(1970));
       expect(absence.endDate, DateTime(1970));
       expect(absence.memberNote, isNull);

--- a/test/data/repositories/absence/absence_local_repository_test.dart
+++ b/test/data/repositories/absence/absence_local_repository_test.dart
@@ -1,7 +1,6 @@
 import 'package:absence_manager/data/repositories/absence/absence_repository_local.dart';
 import 'package:absence_manager/data/services/api/model/absence/absence_api_model.dart';
 import 'package:absence_manager/data/services/local/local_absence_service.dart';
-import 'package:absence_manager/domain/models/absence/absence.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
@@ -19,11 +18,12 @@ void main() {
   });
 
   group('getAllAbsences', () {
-    test('returns list of Absence domain models', () async {
+    test('returns correct number of Absences based on pagination', () async {
       // Arrange
-      final mockApiModels = [
-        AbsenceApiModel(
-          id: 1,
+      final mockApiModels = List.generate(
+        20,
+        (index) => AbsenceApiModel(
+          id: index,
           userId: 123,
           type: "vacation",
           startDate: "2021-01-01",
@@ -36,87 +36,80 @@ void main() {
           crewId: 1,
           status: null,
         ),
-      ];
+      );
 
       when(mockService.fetchAbsences()).thenAnswer((_) async => mockApiModels);
 
       // Act
-      final result = await repository.getAllAbsences();
+      final result = await repository.getAllAbsences(offset: 10, limit: 5);
 
       // Assert
-      expect(result, isA<List<Absence>>());
-      expect(result.length, 1);
-      final absence = result.first;
-      expect(absence.id, 1);
-      expect(absence.userId, 123);
-      expect(absence.type, "vacation");
-      expect(absence.startDate, DateTime(2021, 1, 1));
-      expect(absence.endDate, DateTime(2021, 1, 10));
-      expect(absence.memberNote, "Vacation note");
-      expect(absence.admitterNote, "Admitter note");
-      expect(absence.status, AbsenceStatus.confirmed);
+      expect(result, hasLength(5));
+      expect(result.first.id, 10);
+      expect(result.last.id, 14);
     });
 
-    test('correctly assigns AbsenceStatus based on timestamps', () async {
+    test('returns an empty list when offset exceeds data length', () async {
       // Arrange
-      final mockApiModels = [
-        AbsenceApiModel(
-          id: 1,
+      final mockApiModels = List.generate(
+        10,
+        (index) => AbsenceApiModel(
+          id: index,
           userId: 123,
-          type: "sickness",
+          type: "vacation",
           startDate: "2021-01-01",
           endDate: "2021-01-10",
-          confirmedAt: null,
-          rejectedAt: null,
-          crewId: 1,
-        ),
-        AbsenceApiModel(
-          id: 2,
-          userId: 123,
-          type: "sickness",
-          startDate: "2021-01-01",
-          endDate: "2021-01-10",
+          memberNote: "Vacation note",
+          admitterNote: "Admitter note",
           confirmedAt: "2021-01-05T00:00:00.000+01:00",
+          createdAt: null,
           rejectedAt: null,
           crewId: 1,
+          status: null,
         ),
-        AbsenceApiModel(
-          id: 3,
-          userId: 123,
-          type: "sickness",
-          startDate: "2021-01-01",
-          endDate: "2021-01-10",
-          confirmedAt: null,
-          rejectedAt: "2021-01-06T00:00:00.000+01:00",
-          crewId: 1,
-        ),
-      ];
+      );
 
       when(mockService.fetchAbsences()).thenAnswer((_) async => mockApiModels);
 
       // Act
-      final result = await repository.getAllAbsences();
+      final result = await repository.getAllAbsences(offset: 20, limit: 5);
 
       // Assert
-      expect(result.length, 3);
-      expect(result[0].status, AbsenceStatus.requested);
-      expect(result[1].status, AbsenceStatus.confirmed);
-      expect(result[2].status, AbsenceStatus.rejected);
-    });
-
-    test('returns an empty list when no data available', () async {
-      // Arrange
-      when(mockService.fetchAbsences()).thenAnswer((_) async => []);
-
-      // Act
-      final result = await repository.getAllAbsences();
-
-      // Assert
-      expect(result, isA<List<Absence>>());
       expect(result, isEmpty);
     });
 
-    test('handles null fields gracefully', () async {
+    test('returns the first 10 absences by default', () async {
+      // Arrange
+      final mockApiModels = List.generate(
+        15,
+        (index) => AbsenceApiModel(
+          id: index,
+          userId: 123,
+          type: "vacation",
+          startDate: "2021-01-01",
+          endDate: "2021-01-10",
+          memberNote: "Vacation note",
+          admitterNote: "Admitter note",
+          confirmedAt: "2021-01-05T00:00:00.000+01:00",
+          createdAt: null,
+          rejectedAt: null,
+          crewId: 1,
+          status: null,
+        ),
+      );
+
+      when(mockService.fetchAbsences()).thenAnswer((_) async => mockApiModels);
+
+      // Act
+      final result = await repository.getAllAbsences();
+
+      // Assert
+      expect(result, hasLength(10));
+      expect(result.first.id, 0);
+      expect(result.last.id, 9);
+    });
+
+    test('handles null fields gracefully with pagination', () async {
       // Arrange
       final mockApiModels = [
         AbsenceApiModel(
@@ -136,7 +129,7 @@ void main() {
       when(mockService.fetchAbsences()).thenAnswer((_) async => mockApiModels);
 
       // Act
-      final result = await repository.getAllAbsences();
+      final result = await repository.getAllAbsences(offset: 0, limit: 1);
 
       // Assert
       expect(result.length, 1);

--- a/test/domain/usecases/get_absences_with_members_use_case_test.dart
+++ b/test/domain/usecases/get_absences_with_members_use_case_test.dart
@@ -1,6 +1,7 @@
 import 'package:absence_manager/data/repositories/absence/absence_repository.dart';
 import 'package:absence_manager/data/repositories/member/member_repository.dart';
 import 'package:absence_manager/domain/models/absence/absence.dart';
+import 'package:absence_manager/domain/models/absence/absence_list.dart';
 import 'package:absence_manager/domain/models/absence_with_member.dart';
 import 'package:absence_manager/domain/models/member/member.dart';
 import 'package:absence_manager/domain/use_cases/get_absences_with_members_use_case.dart';
@@ -23,7 +24,7 @@ void main() {
   });
 
   group('GetAbsencesWithMembersUseCase', () {
-    test('returns first page of AbsenceWithMember list when userIds match', () async {
+    test('returns AbsenceListWithMembers with correct total count and members', () async {
       final absences = [
         Absence(
           id: 1,
@@ -52,94 +53,56 @@ void main() {
       ];
 
       when(
-        mockAbsenceRepo.getAllAbsences(offset: 0, limit: 1),
-      ).thenAnswer((_) async => [absences[0]]);
+        mockAbsenceRepo.getAllAbsences(offset: 0, limit: 10),
+      ).thenAnswer((_) async => AbsenceList(totalCount: 2, absences: absences));
       when(mockMemberRepo.getAllMembers()).thenAnswer((_) async => members);
 
-      final result = await useCase.execute(offset: 0, limit: 1);
+      final result = await useCase.execute(offset: 0, limit: 10);
 
-      expect(result, isA<List<AbsenceWithMember>>());
-      expect(result.length, 1);
-      expect(result.first.absence.id, 1);
-      expect(result.first.member.name, "Alice");
+      expect(result.totalCount, 2);
+      expect(result.absences, isA<List<AbsenceWithMember>>());
+      expect(result.absences.length, 2);
+      expect(result.absences.first.absence.id, 1);
+      expect(result.absences.first.member.name, "Alice");
     });
 
-    test('returns second page of AbsenceWithMember list when userIds match', () async {
+    test('uses fallback "Unknown" member if no matching userId is found', () async {
       final absences = [
         Absence(
           id: 1,
-          userId: 101,
+          userId: 999,
           type: "vacation",
           startDate: DateTime(2021, 1, 1),
           endDate: DateTime(2021, 1, 5),
-          memberNote: "Ski trip",
-          admitterNote: "Approved",
-          status: AbsenceStatus.confirmed,
-        ),
-        Absence(
-          id: 2,
-          userId: 101,
-          type: "vacation",
-          startDate: DateTime(2021, 1, 6),
-          endDate: DateTime(2021, 1, 10),
-          memberNote: "Ski trip",
-          admitterNote: "Approved",
-          status: AbsenceStatus.confirmed,
-        ),
-      ];
-
-      final members = [
-        Member(userId: 101, name: "Alice", imageUrl: "http://example.com/image.png"),
-      ];
-
-      when(
-        mockAbsenceRepo.getAllAbsences(offset: 1, limit: 1),
-      ).thenAnswer((_) async => [absences[1]]);
-      when(mockMemberRepo.getAllMembers()).thenAnswer((_) async => members);
-
-      final result = await useCase.execute(offset: 1, limit: 1);
-
-      expect(result, isA<List<AbsenceWithMember>>());
-      expect(result.length, 1);
-      expect(result.first.absence.id, 2);
-      expect(result.first.member.name, "Alice");
-    });
-
-    test('returns empty list when offset exceeds total absences', () async {
-      final members = [
-        Member(userId: 101, name: "Alice", imageUrl: "http://example.com/image.png"),
-      ];
-
-      when(mockAbsenceRepo.getAllAbsences(offset: 20, limit: 1)).thenAnswer((_) async => []);
-      when(mockMemberRepo.getAllMembers()).thenAnswer((_) async => members);
-
-      final result = await useCase.execute(offset: 20, limit: 1);
-
-      expect(result, isEmpty);
-    });
-
-    test('uses fallback "Unknown" member for all absences if member list is empty', () async {
-      final absences = [
-        Absence(
-          id: 3,
-          userId: 101,
-          type: "vacation",
-          startDate: DateTime(2021, 3, 1),
-          endDate: DateTime(2021, 3, 5),
-          memberNote: null,
-          admitterNote: null,
+          memberNote: "Unknown trip",
+          admitterNote: "Unknown",
           status: AbsenceStatus.requested,
         ),
       ];
 
-      when(mockAbsenceRepo.getAllAbsences(offset: 0, limit: 1)).thenAnswer((_) async => absences);
+      when(
+        mockAbsenceRepo.getAllAbsences(offset: 0, limit: 10),
+      ).thenAnswer((_) async => AbsenceList(totalCount: 1, absences: absences));
       when(mockMemberRepo.getAllMembers()).thenAnswer((_) async => []);
 
-      final result = await useCase.execute(offset: 0, limit: 1);
+      final result = await useCase.execute(offset: 0, limit: 10);
 
-      expect(result.length, 1);
-      expect(result.first.member.name, "Unknown");
-      expect(result.first.member.userId, 101); // fallback still keeps the userId
+      expect(result.totalCount, 1);
+      expect(result.absences, isA<List<AbsenceWithMember>>());
+      expect(result.absences.length, 1);
+      expect(result.absences.first.member.name, "Unknown");
+    });
+
+    test('returns empty AbsenceListWithMembers if no absences exist', () async {
+      when(
+        mockAbsenceRepo.getAllAbsences(offset: 0, limit: 10),
+      ).thenAnswer((_) async => AbsenceList(totalCount: 0, absences: []));
+      when(mockMemberRepo.getAllMembers()).thenAnswer((_) async => []);
+
+      final result = await useCase.execute(offset: 0, limit: 10);
+
+      expect(result.totalCount, 0);
+      expect(result.absences, isEmpty);
     });
   });
 }

--- a/test/domain/usecases/get_absences_with_members_use_case_test.dart
+++ b/test/domain/usecases/get_absences_with_members_use_case_test.dart
@@ -22,91 +22,124 @@ void main() {
     useCase = GetAbsencesWithMembersUseCase(mockAbsenceRepo, mockMemberRepo);
   });
 
-  test('returns combined AbsenceWithMember list when userIds match', () async {
-    final absences = [
-      Absence(
-        id: 1,
-        userId: 101,
-        type: "vacation",
-        startDate: DateTime(2021, 1, 1),
-        endDate: DateTime(2021, 1, 5),
-        memberNote: "Ski trip",
-        admitterNote: "Approved",
-        status: AbsenceStatus.confirmed,
-      ),
-    ];
+  group('GetAbsencesWithMembersUseCase', () {
+    test('returns first page of AbsenceWithMember list when userIds match', () async {
+      final absences = [
+        Absence(
+          id: 1,
+          userId: 101,
+          type: "vacation",
+          startDate: DateTime(2021, 1, 1),
+          endDate: DateTime(2021, 1, 5),
+          memberNote: "Ski trip",
+          admitterNote: "Approved",
+          status: AbsenceStatus.confirmed,
+        ),
+        Absence(
+          id: 2,
+          userId: 101,
+          type: "vacation",
+          startDate: DateTime(2021, 1, 6),
+          endDate: DateTime(2021, 1, 10),
+          memberNote: "Ski trip",
+          admitterNote: "Approved",
+          status: AbsenceStatus.confirmed,
+        ),
+      ];
 
-    final members = [Member(userId: 101, name: "Alice", imageUrl: "http://example.com/image.png")];
+      final members = [
+        Member(userId: 101, name: "Alice", imageUrl: "http://example.com/image.png"),
+      ];
 
-    when(mockAbsenceRepo.getAllAbsences()).thenAnswer((_) async => absences);
-    when(mockMemberRepo.getAllMembers()).thenAnswer((_) async => members);
+      when(
+        mockAbsenceRepo.getAllAbsences(offset: 0, limit: 1),
+      ).thenAnswer((_) async => [absences[0]]);
+      when(mockMemberRepo.getAllMembers()).thenAnswer((_) async => members);
 
-    final result = await useCase.execute();
+      final result = await useCase.execute(offset: 0, limit: 1);
 
-    expect(result, isA<List<AbsenceWithMember>>());
-    expect(result.length, 1);
-    expect(result.first.absence.id, 1);
-    expect(result.first.member.name, "Alice");
-  });
+      expect(result, isA<List<AbsenceWithMember>>());
+      expect(result.length, 1);
+      expect(result.first.absence.id, 1);
+      expect(result.first.member.name, "Alice");
+    });
 
-  test('uses fallback "Unknown" member when member is missing', () async {
-    final absences = [
-      Absence(
-        id: 2,
-        userId: 999, // userId not in member list
-        type: "sickness",
-        startDate: DateTime(2021, 2, 1),
-        endDate: DateTime(2021, 2, 3),
-        memberNote: null,
-        admitterNote: null,
-        status: AbsenceStatus.requested,
-      ),
-    ];
+    test('returns second page of AbsenceWithMember list when userIds match', () async {
+      final absences = [
+        Absence(
+          id: 1,
+          userId: 101,
+          type: "vacation",
+          startDate: DateTime(2021, 1, 1),
+          endDate: DateTime(2021, 1, 5),
+          memberNote: "Ski trip",
+          admitterNote: "Approved",
+          status: AbsenceStatus.confirmed,
+        ),
+        Absence(
+          id: 2,
+          userId: 101,
+          type: "vacation",
+          startDate: DateTime(2021, 1, 6),
+          endDate: DateTime(2021, 1, 10),
+          memberNote: "Ski trip",
+          admitterNote: "Approved",
+          status: AbsenceStatus.confirmed,
+        ),
+      ];
 
-    final members = [Member(userId: 101, name: "Alice", imageUrl: "http://example.com/image.png")];
+      final members = [
+        Member(userId: 101, name: "Alice", imageUrl: "http://example.com/image.png"),
+      ];
 
-    when(mockAbsenceRepo.getAllAbsences()).thenAnswer((_) async => absences);
-    when(mockMemberRepo.getAllMembers()).thenAnswer((_) async => members);
+      when(
+        mockAbsenceRepo.getAllAbsences(offset: 1, limit: 1),
+      ).thenAnswer((_) async => [absences[1]]);
+      when(mockMemberRepo.getAllMembers()).thenAnswer((_) async => members);
 
-    final result = await useCase.execute();
+      final result = await useCase.execute(offset: 1, limit: 1);
 
-    expect(result.length, 1);
-    expect(result.first.absence.userId, 999);
-    expect(result.first.member.name, "Unknown");
-  });
+      expect(result, isA<List<AbsenceWithMember>>());
+      expect(result.length, 1);
+      expect(result.first.absence.id, 2);
+      expect(result.first.member.name, "Alice");
+    });
 
-  test('returns empty list when no absences exist', () async {
-    final members = [Member(userId: 101, name: "Alice", imageUrl: "http://example.com/image.png")];
+    test('returns empty list when offset exceeds total absences', () async {
+      final members = [
+        Member(userId: 101, name: "Alice", imageUrl: "http://example.com/image.png"),
+      ];
 
-    when(mockAbsenceRepo.getAllAbsences()).thenAnswer((_) async => []);
-    when(mockMemberRepo.getAllMembers()).thenAnswer((_) async => members);
+      when(mockAbsenceRepo.getAllAbsences(offset: 20, limit: 1)).thenAnswer((_) async => []);
+      when(mockMemberRepo.getAllMembers()).thenAnswer((_) async => members);
 
-    final result = await useCase.execute();
+      final result = await useCase.execute(offset: 20, limit: 1);
 
-    expect(result, isEmpty);
-  });
+      expect(result, isEmpty);
+    });
 
-  test('uses fallback "Unknown" for all absences if member list is empty', () async {
-    final absences = [
-      Absence(
-        id: 3,
-        userId: 101,
-        type: "vacation",
-        startDate: DateTime(2021, 3, 1),
-        endDate: DateTime(2021, 3, 5),
-        memberNote: null,
-        admitterNote: null,
-        status: AbsenceStatus.requested,
-      ),
-    ];
+    test('uses fallback "Unknown" member for all absences if member list is empty', () async {
+      final absences = [
+        Absence(
+          id: 3,
+          userId: 101,
+          type: "vacation",
+          startDate: DateTime(2021, 3, 1),
+          endDate: DateTime(2021, 3, 5),
+          memberNote: null,
+          admitterNote: null,
+          status: AbsenceStatus.requested,
+        ),
+      ];
 
-    when(mockAbsenceRepo.getAllAbsences()).thenAnswer((_) async => absences);
-    when(mockMemberRepo.getAllMembers()).thenAnswer((_) async => []);
+      when(mockAbsenceRepo.getAllAbsences(offset: 0, limit: 1)).thenAnswer((_) async => absences);
+      when(mockMemberRepo.getAllMembers()).thenAnswer((_) async => []);
 
-    final result = await useCase.execute();
+      final result = await useCase.execute(offset: 0, limit: 1);
 
-    expect(result.length, 1);
-    expect(result.first.member.name, "Unknown");
-    expect(result.first.member.userId, 101); // fallback still keeps the userId
+      expect(result.length, 1);
+      expect(result.first.member.name, "Unknown");
+      expect(result.first.member.userId, 101); // fallback still keeps the userId
+    });
   });
 }

--- a/test/domain/usecases/get_absences_with_members_use_case_test.mocks.dart
+++ b/test/domain/usecases/get_absences_with_members_use_case_test.mocks.dart
@@ -36,9 +36,15 @@ class MockAbsenceRepository extends _i1.Mock implements _i2.AbsenceRepository {
   }
 
   @override
-  _i3.Future<List<_i4.Absence>> getAllAbsences() =>
+  _i3.Future<List<_i4.Absence>> getAllAbsences({
+    required int? offset,
+    required int? limit,
+  }) =>
       (super.noSuchMethod(
-            Invocation.method(#getAllAbsences, []),
+            Invocation.method(#getAllAbsences, [], {
+              #offset: offset,
+              #limit: limit,
+            }),
             returnValue: _i3.Future<List<_i4.Absence>>.value(<_i4.Absence>[]),
           )
           as _i3.Future<List<_i4.Absence>>);

--- a/test/domain/usecases/get_absences_with_members_use_case_test.mocks.dart
+++ b/test/domain/usecases/get_absences_with_members_use_case_test.mocks.dart
@@ -3,13 +3,13 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i3;
+import 'dart:async' as _i4;
 
 import 'package:absence_manager/data/repositories/absence/absence_repository.dart'
-    as _i2;
+    as _i3;
 import 'package:absence_manager/data/repositories/member/member_repository.dart'
     as _i5;
-import 'package:absence_manager/domain/models/absence/absence.dart' as _i4;
+import 'package:absence_manager/domain/models/absence/absence_list.dart' as _i2;
 import 'package:absence_manager/domain/models/member/member.dart' as _i6;
 import 'package:mockito/mockito.dart' as _i1;
 
@@ -27,16 +27,21 @@ import 'package:mockito/mockito.dart' as _i1;
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
 
+class _FakeAbsenceList_0 extends _i1.SmartFake implements _i2.AbsenceList {
+  _FakeAbsenceList_0(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
+}
+
 /// A class which mocks [AbsenceRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockAbsenceRepository extends _i1.Mock implements _i2.AbsenceRepository {
+class MockAbsenceRepository extends _i1.Mock implements _i3.AbsenceRepository {
   MockAbsenceRepository() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i3.Future<List<_i4.Absence>> getAllAbsences({
+  _i4.Future<_i2.AbsenceList> getAllAbsences({
     required int? offset,
     required int? limit,
   }) =>
@@ -45,9 +50,17 @@ class MockAbsenceRepository extends _i1.Mock implements _i2.AbsenceRepository {
               #offset: offset,
               #limit: limit,
             }),
-            returnValue: _i3.Future<List<_i4.Absence>>.value(<_i4.Absence>[]),
+            returnValue: _i4.Future<_i2.AbsenceList>.value(
+              _FakeAbsenceList_0(
+                this,
+                Invocation.method(#getAllAbsences, [], {
+                  #offset: offset,
+                  #limit: limit,
+                }),
+              ),
+            ),
           )
-          as _i3.Future<List<_i4.Absence>>);
+          as _i4.Future<_i2.AbsenceList>);
 }
 
 /// A class which mocks [MemberRepository].
@@ -59,10 +72,10 @@ class MockMemberRepository extends _i1.Mock implements _i5.MemberRepository {
   }
 
   @override
-  _i3.Future<List<_i6.Member>> getAllMembers() =>
+  _i4.Future<List<_i6.Member>> getAllMembers() =>
       (super.noSuchMethod(
             Invocation.method(#getAllMembers, []),
-            returnValue: _i3.Future<List<_i6.Member>>.value(<_i6.Member>[]),
+            returnValue: _i4.Future<List<_i6.Member>>.value(<_i6.Member>[]),
           )
-          as _i3.Future<List<_i6.Member>>);
+          as _i4.Future<List<_i6.Member>>);
 }

--- a/test/ui/absences_screen/bloc/absences_bloc_test.dart
+++ b/test/ui/absences_screen/bloc/absences_bloc_test.dart
@@ -1,4 +1,5 @@
 import 'package:absence_manager/domain/models/absence/absence.dart';
+import 'package:absence_manager/domain/models/absence_list_with_members.dart';
 import 'package:absence_manager/domain/models/absence_with_member.dart';
 import 'package:absence_manager/domain/models/member/member.dart';
 import 'package:absence_manager/domain/use_cases/get_absences_with_members_use_case.dart';
@@ -15,9 +16,15 @@ import 'absences_bloc_test.mocks.dart';
 
 void main() {
   late MockGetAbsencesWithMembersUseCase mockUseCase;
+  late AbsencesBloc absencesBloc;
 
   setUp(() {
     mockUseCase = MockGetAbsencesWithMembersUseCase();
+    absencesBloc = AbsencesBloc(mockUseCase);
+  });
+
+  tearDown(() {
+    absencesBloc.close();
   });
 
   final absence = Absence(
@@ -33,51 +40,41 @@ void main() {
 
   final member = Member(userId: 100, name: 'Alice', imageUrl: '');
 
-  final combined = [AbsenceWithMember(absence: absence, member: member)];
-
-  final moreAbsences = [
-    AbsenceWithMember(
-      absence: Absence(
-        id: 2,
-        // new ID
-        userId: absence.userId,
-        type: absence.type,
-        startDate: DateTime(2024, 1, 11),
-        // new start date
-        endDate: absence.endDate,
-        memberNote: absence.memberNote,
-        admitterNote: absence.admitterNote,
-        status: absence.status,
-      ),
-      member: member,
-    ),
-  ];
-
-  blocTest<AbsencesBloc, AbsencesState>(
-    'emits [Loading, Loaded] when use case succeeds',
-    build: () {
-      when(mockUseCase.execute(offset: 0, limit: 10)).thenAnswer((_) async => combined);
-      return AbsencesBloc(mockUseCase);
-    },
-    act: (bloc) => bloc.add(LoadAbsences()),
-    expect: () => [AbsencesLoading(), AbsencesLoaded(combined)],
+  final absenceListWithMembers = AbsenceListWithMembers(
+    totalCount: 1,
+    absences: [AbsenceWithMember(absence: absence, member: member)],
   );
 
   blocTest<AbsencesBloc, AbsencesState>(
-    'emits [Loading, Loaded (empty)] when use case returns empty list',
+    'emits [AbsencesLoading, AbsencesLoaded] when LoadAbsences event is added',
     build: () {
-      when(mockUseCase.execute(offset: 0, limit: 10)).thenAnswer((_) async => []);
-      return AbsencesBloc(mockUseCase);
+      when(
+        mockUseCase.execute(offset: 0, limit: 10),
+      ).thenAnswer((_) async => absenceListWithMembers);
+      return absencesBloc;
     },
     act: (bloc) => bloc.add(LoadAbsences()),
-    expect: () => [AbsencesLoading(), AbsencesLoaded([])],
+    expect:
+        () => [
+          AbsencesLoading(),
+          AbsencesLoaded(
+            absences: absenceListWithMembers.absences,
+            hasMore: absenceListWithMembers.absences.length == 10,
+            totalCount: absenceListWithMembers.totalCount,
+          ),
+        ],
+    verify: (_) {
+      verify(mockUseCase.execute(offset: 0, limit: 10)).called(1);
+    },
   );
 
   blocTest<AbsencesBloc, AbsencesState>(
-    'emits [Loading, Error] when use case throws',
+    'emits [AbsencesLoading, AbsencesError] when LoadAbsences event fails',
     build: () {
-      when(mockUseCase.execute(offset: 0, limit: 10)).thenThrow(Exception("Oops"));
-      return AbsencesBloc(mockUseCase);
+      when(
+        mockUseCase.execute(offset: 0, limit: 10),
+      ).thenThrow(Exception('Failed to fetch absences'));
+      return absencesBloc;
     },
     act: (bloc) => bloc.add(LoadAbsences()),
     expect: () => [AbsencesLoading(), isA<AbsencesError>()],
@@ -87,77 +84,55 @@ void main() {
   );
 
   blocTest<AbsencesBloc, AbsencesState>(
-    'handles multiple LoadAbsences events sequentially',
+    'emits [AbsencesLoadingMore, AbsencesLoaded] when LoadMoreAbsences event is added',
     build: () {
-      when(mockUseCase.execute(offset: 0, limit: 10)).thenAnswer((_) async => combined);
-      return AbsencesBloc(mockUseCase);
-    },
-    act: (bloc) async {
-      bloc.add(LoadAbsences());
-      await Future.delayed(const Duration(milliseconds: 10));
-      bloc.add(LoadAbsences());
-    },
-    wait: const Duration(milliseconds: 50),
-    expect:
-        () => [
-          AbsencesLoading(),
-          AbsencesLoaded(combined),
-          AbsencesLoading(),
-          AbsencesLoaded(combined),
-        ],
-    verify: (_) {
-      verify(mockUseCase.execute(offset: 0, limit: 10)).called(2);
-    },
-  );
+      final currentState = AbsencesLoaded(
+        absences: absenceListWithMembers.absences,
+        hasMore: true,
+        totalCount: absenceListWithMembers.totalCount,
+      );
 
-  blocTest<AbsencesBloc, AbsencesState>(
-    'emits [LoadingMore, Loaded] with combined absences when loading more absences',
-    build: () {
-      when(mockUseCase.execute(offset: 0, limit: 10)).thenAnswer((_) async => combined);
-      when(mockUseCase.execute(offset: 10, limit: 10)).thenAnswer((_) async => moreAbsences);
-      return AbsencesBloc(mockUseCase);
+      absencesBloc.emit(currentState);
+
+      when(
+        mockUseCase.execute(offset: 10, limit: 10),
+      ).thenAnswer((_) async => absenceListWithMembers);
+      return absencesBloc;
     },
-    act: (bloc) async {
-      bloc.add(LoadAbsences());
-      await Future.delayed(const Duration(milliseconds: 10));
-      bloc.add(LoadMoreAbsences(offset: 10, limit: 10));
-    },
-    wait: const Duration(milliseconds: 50),
+    act: (bloc) => bloc.add(LoadMoreAbsences(offset: 10, limit: 10)),
     expect:
         () => [
-          AbsencesLoading(),
-          AbsencesLoaded(combined),
           AbsencesLoadingMore(),
-          AbsencesLoaded([...combined, ...moreAbsences]),
+          AbsencesLoaded(
+            absences: absenceListWithMembers.absences + absenceListWithMembers.absences,
+            hasMore: absenceListWithMembers.absences.length == 10,
+            totalCount: absenceListWithMembers.totalCount,
+          ),
         ],
     verify: (_) {
-      verify(mockUseCase.execute(offset: 0, limit: 10)).called(1);
       verify(mockUseCase.execute(offset: 10, limit: 10)).called(1);
     },
   );
 
   blocTest<AbsencesBloc, AbsencesState>(
-    'stops loading more when no additional data is returned',
+    'emits [AbsencesLoadingMore, AbsencesError] when LoadMoreAbsences fails',
     build: () {
-      when(mockUseCase.execute(offset: 0, limit: 10)).thenAnswer((_) async => combined);
-      when(mockUseCase.execute(offset: 10, limit: 10)).thenAnswer((_) async => []);
-      return AbsencesBloc(mockUseCase);
+      final currentState = AbsencesLoaded(
+        absences: absenceListWithMembers.absences,
+        hasMore: true,
+        totalCount: absenceListWithMembers.totalCount,
+      );
+
+      absencesBloc.emit(currentState);
+
+      when(
+        mockUseCase.execute(offset: 10, limit: 10),
+      ).thenThrow(Exception('Failed to fetch more absences'));
+      return absencesBloc;
     },
-    act: (bloc) async {
-      bloc.add(LoadAbsences());
-      await Future.delayed(const Duration(milliseconds: 10));
-      bloc.add(LoadMoreAbsences(offset: 10, limit: 10));
-    },
-    wait: const Duration(milliseconds: 50),
-    expect:
-        () => [
-          AbsencesLoading(),
-          AbsencesLoaded(combined),
-          AbsencesLoadingMore(),
-          AbsencesLoaded(combined, hasMore: false),
-        ],
+    act: (bloc) => bloc.add(LoadMoreAbsences(offset: 10, limit: 10)),
+    expect: () => [AbsencesLoadingMore(), isA<AbsencesError>()],
     verify: (_) {
-      verify(mockUseCase.execute(offset: 0, limit: 10)).called(1);
       verify(mockUseCase.execute(offset: 10, limit: 10)).called(1);
     },
   );

--- a/test/ui/absences_screen/bloc/absences_bloc_test.dart
+++ b/test/ui/absences_screen/bloc/absences_bloc_test.dart
@@ -35,10 +35,28 @@ void main() {
 
   final combined = [AbsenceWithMember(absence: absence, member: member)];
 
+  final moreAbsences = [
+    AbsenceWithMember(
+      absence: Absence(
+        id: 2,
+        // new ID
+        userId: absence.userId,
+        type: absence.type,
+        startDate: DateTime(2024, 1, 11),
+        // new start date
+        endDate: absence.endDate,
+        memberNote: absence.memberNote,
+        admitterNote: absence.admitterNote,
+        status: absence.status,
+      ),
+      member: member,
+    ),
+  ];
+
   blocTest<AbsencesBloc, AbsencesState>(
     'emits [Loading, Loaded] when use case succeeds',
     build: () {
-      when(mockUseCase.execute()).thenAnswer((_) async => combined);
+      when(mockUseCase.execute(offset: 0, limit: 10)).thenAnswer((_) async => combined);
       return AbsencesBloc(mockUseCase);
     },
     act: (bloc) => bloc.add(LoadAbsences()),
@@ -48,7 +66,7 @@ void main() {
   blocTest<AbsencesBloc, AbsencesState>(
     'emits [Loading, Loaded (empty)] when use case returns empty list',
     build: () {
-      when(mockUseCase.execute()).thenAnswer((_) async => []);
+      when(mockUseCase.execute(offset: 0, limit: 10)).thenAnswer((_) async => []);
       return AbsencesBloc(mockUseCase);
     },
     act: (bloc) => bloc.add(LoadAbsences()),
@@ -58,20 +76,20 @@ void main() {
   blocTest<AbsencesBloc, AbsencesState>(
     'emits [Loading, Error] when use case throws',
     build: () {
-      when(mockUseCase.execute()).thenThrow(Exception("Oops"));
+      when(mockUseCase.execute(offset: 0, limit: 10)).thenThrow(Exception("Oops"));
       return AbsencesBloc(mockUseCase);
     },
     act: (bloc) => bloc.add(LoadAbsences()),
     expect: () => [AbsencesLoading(), isA<AbsencesError>()],
     verify: (_) {
-      verify(mockUseCase.execute()).called(1);
+      verify(mockUseCase.execute(offset: 0, limit: 10)).called(1);
     },
   );
 
   blocTest<AbsencesBloc, AbsencesState>(
     'handles multiple LoadAbsences events sequentially',
     build: () {
-      when(mockUseCase.execute()).thenAnswer((_) async => combined);
+      when(mockUseCase.execute(offset: 0, limit: 10)).thenAnswer((_) async => combined);
       return AbsencesBloc(mockUseCase);
     },
     act: (bloc) async {
@@ -88,7 +106,59 @@ void main() {
           AbsencesLoaded(combined),
         ],
     verify: (_) {
-      verify(mockUseCase.execute()).called(2);
+      verify(mockUseCase.execute(offset: 0, limit: 10)).called(2);
+    },
+  );
+
+  blocTest<AbsencesBloc, AbsencesState>(
+    'emits [LoadingMore, Loaded] with combined absences when loading more absences',
+    build: () {
+      when(mockUseCase.execute(offset: 0, limit: 10)).thenAnswer((_) async => combined);
+      when(mockUseCase.execute(offset: 10, limit: 10)).thenAnswer((_) async => moreAbsences);
+      return AbsencesBloc(mockUseCase);
+    },
+    act: (bloc) async {
+      bloc.add(LoadAbsences());
+      await Future.delayed(const Duration(milliseconds: 10));
+      bloc.add(LoadMoreAbsences(offset: 10, limit: 10));
+    },
+    wait: const Duration(milliseconds: 50),
+    expect:
+        () => [
+          AbsencesLoading(),
+          AbsencesLoaded(combined),
+          AbsencesLoadingMore(),
+          AbsencesLoaded([...combined, ...moreAbsences]),
+        ],
+    verify: (_) {
+      verify(mockUseCase.execute(offset: 0, limit: 10)).called(1);
+      verify(mockUseCase.execute(offset: 10, limit: 10)).called(1);
+    },
+  );
+
+  blocTest<AbsencesBloc, AbsencesState>(
+    'stops loading more when no additional data is returned',
+    build: () {
+      when(mockUseCase.execute(offset: 0, limit: 10)).thenAnswer((_) async => combined);
+      when(mockUseCase.execute(offset: 10, limit: 10)).thenAnswer((_) async => []);
+      return AbsencesBloc(mockUseCase);
+    },
+    act: (bloc) async {
+      bloc.add(LoadAbsences());
+      await Future.delayed(const Duration(milliseconds: 10));
+      bloc.add(LoadMoreAbsences(offset: 10, limit: 10));
+    },
+    wait: const Duration(milliseconds: 50),
+    expect:
+        () => [
+          AbsencesLoading(),
+          AbsencesLoaded(combined),
+          AbsencesLoadingMore(),
+          AbsencesLoaded(combined, hasMore: false),
+        ],
+    verify: (_) {
+      verify(mockUseCase.execute(offset: 0, limit: 10)).called(1);
+      verify(mockUseCase.execute(offset: 10, limit: 10)).called(1);
     },
   );
 }

--- a/test/ui/absences_screen/bloc/absences_bloc_test.mocks.dart
+++ b/test/ui/absences_screen/bloc/absences_bloc_test.mocks.dart
@@ -72,9 +72,12 @@ class MockGetAbsencesWithMembersUseCase extends _i1.Mock
           as _i3.MemberRepository);
 
   @override
-  _i5.Future<List<_i6.AbsenceWithMember>> execute() =>
+  _i5.Future<List<_i6.AbsenceWithMember>> execute({
+    int? offset = 0,
+    int? limit = 10,
+  }) =>
       (super.noSuchMethod(
-            Invocation.method(#execute, []),
+            Invocation.method(#execute, [], {#offset: offset, #limit: limit}),
             returnValue: _i5.Future<List<_i6.AbsenceWithMember>>.value(
               <_i6.AbsenceWithMember>[],
             ),

--- a/test/ui/absences_screen/bloc/absences_bloc_test.mocks.dart
+++ b/test/ui/absences_screen/bloc/absences_bloc_test.mocks.dart
@@ -3,15 +3,16 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i5;
+import 'dart:async' as _i6;
 
 import 'package:absence_manager/data/repositories/absence/absence_repository.dart'
     as _i2;
 import 'package:absence_manager/data/repositories/member/member_repository.dart'
     as _i3;
-import 'package:absence_manager/domain/models/absence_with_member.dart' as _i6;
-import 'package:absence_manager/domain/use_cases/get_absences_with_members_use_case.dart'
+import 'package:absence_manager/domain/models/absence_list_with_members.dart'
     as _i4;
+import 'package:absence_manager/domain/use_cases/get_absences_with_members_use_case.dart'
+    as _i5;
 import 'package:mockito/mockito.dart' as _i1;
 
 // ignore_for_file: type=lint
@@ -40,11 +41,17 @@ class _FakeMemberRepository_1 extends _i1.SmartFake
     : super(parent, parentInvocation);
 }
 
+class _FakeAbsenceListWithMembers_2 extends _i1.SmartFake
+    implements _i4.AbsenceListWithMembers {
+  _FakeAbsenceListWithMembers_2(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
+}
+
 /// A class which mocks [GetAbsencesWithMembersUseCase].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockGetAbsencesWithMembersUseCase extends _i1.Mock
-    implements _i4.GetAbsencesWithMembersUseCase {
+    implements _i5.GetAbsencesWithMembersUseCase {
   MockGetAbsencesWithMembersUseCase() {
     _i1.throwOnMissingStub(this);
   }
@@ -72,15 +79,21 @@ class MockGetAbsencesWithMembersUseCase extends _i1.Mock
           as _i3.MemberRepository);
 
   @override
-  _i5.Future<List<_i6.AbsenceWithMember>> execute({
+  _i6.Future<_i4.AbsenceListWithMembers> execute({
     int? offset = 0,
     int? limit = 10,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#execute, [], {#offset: offset, #limit: limit}),
-            returnValue: _i5.Future<List<_i6.AbsenceWithMember>>.value(
-              <_i6.AbsenceWithMember>[],
+            returnValue: _i6.Future<_i4.AbsenceListWithMembers>.value(
+              _FakeAbsenceListWithMembers_2(
+                this,
+                Invocation.method(#execute, [], {
+                  #offset: offset,
+                  #limit: limit,
+                }),
+              ),
             ),
           )
-          as _i5.Future<List<_i6.AbsenceWithMember>>);
+          as _i6.Future<_i4.AbsenceListWithMembers>);
 }


### PR DESCRIPTION
This PR introduces pagination support and displays the total count of absences. It includes:

- Updating the AbsenceRepository to handle paginated data.

- Modifications to the GetAbsencesWithMembersUseCase to return both paginated absences and the total count.

- Adjustments to the UI layer to show total absences and the current number fetched.

- Updated tests ensuring that pagination logic works as expected and the total count is accurately retrieved and displayed.