### PR TITLE
Implement filtering by type and date + refactor absence type to enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ A Flutter application to manage and display employee absences. It includes featu
 - [x] Admitter note (when available)
 
 ### Filters & UI States
-- [ ] Filter absences by type
-- [ ] Filter absences by date
+- [x] Filter absences by type
+- [x] Filter absences by date
 - [x] Show a loading state while data is being fetched
 - [x] Show an error state if the list fails to load
 - [x] Show an empty state if no results are found

--- a/lib/data/repositories/absence/absence_repository_local.dart
+++ b/lib/data/repositories/absence/absence_repository_local.dart
@@ -2,6 +2,7 @@ import 'package:absence_manager/data/repositories/absence/absence_repository.dar
 import 'package:absence_manager/data/services/local/local_absence_service.dart';
 import 'package:absence_manager/domain/models/absence/absence.dart';
 import 'package:absence_manager/domain/models/absence/absence_list.dart';
+import 'package:absence_manager/domain/models/absence/absence_type.dart';
 
 class AbsenceLocalRepository implements AbsenceRepository {
   final LocalAbsenceService service;
@@ -26,7 +27,7 @@ class AbsenceLocalRepository implements AbsenceRepository {
               return Absence(
                 id: dto.id ?? -1,
                 userId: dto.userId ?? -1,
-                type: dto.type ?? '',
+                type: AbsenceTypeX.fromString(dto.type),
                 startDate: DateTime.tryParse(dto.startDate ?? '') ?? DateTime(1970),
                 endDate: DateTime.tryParse(dto.endDate ?? '') ?? DateTime(1970),
                 memberNote: dto.memberNote?.trim().isEmpty ?? true ? null : dto.memberNote,

--- a/lib/domain/models/absence/absence.dart
+++ b/lib/domain/models/absence/absence.dart
@@ -3,10 +3,12 @@
 // to keep the domain layer decoupled from dependencies and tooling,
 // as per clean architecture principles.
 
+import 'package:absence_manager/domain/models/absence/absence_type.dart';
+
 class Absence {
   final int id;
   final int userId;
-  final String type; // 'vacation', 'sickness'
+  final AbsenceType type; // 'vacation', 'sickness'
   final DateTime startDate;
   final DateTime endDate;
   final String? memberNote;

--- a/lib/domain/models/absence/absence_type.dart
+++ b/lib/domain/models/absence/absence_type.dart
@@ -1,0 +1,26 @@
+enum AbsenceType { vacation, sickness, none }
+
+// Use Dart-style enum extension naming (e.g., ThemeModeX, LocaleX) for consistency
+extension AbsenceTypeX on AbsenceType {
+  static AbsenceType fromString(String? value) {
+    switch (value?.toLowerCase()) {
+      case 'vacation':
+        return AbsenceType.vacation;
+      case 'sickness':
+        return AbsenceType.sickness;
+      default:
+        return AbsenceType.none;
+    }
+  }
+
+  String get label {
+    switch (this) {
+      case AbsenceType.vacation:
+        return 'Vacation';
+      case AbsenceType.sickness:
+        return 'Sickness';
+      case AbsenceType.none:
+        return 'Unknown';
+    }
+  }
+}

--- a/lib/ui/absence/bloc/absence_bloc.dart
+++ b/lib/ui/absence/bloc/absence_bloc.dart
@@ -1,3 +1,4 @@
+import 'package:absence_manager/domain/models/absence/absence_type.dart';
 import 'package:absence_manager/domain/use_cases/get_absences_with_members_use_case.dart';
 import 'package:absence_manager/ui/absence/bloc/absence_event.dart';
 import 'package:absence_manager/ui/absence/bloc/absence_state.dart';
@@ -8,7 +9,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 class AbsencesBloc extends Bloc<AbsencesEvent, AbsencesState> {
   final GetAbsencesWithMembersUseCase useCase;
 
-  String? _selectedType;
+  AbsenceType? _selectedType;
   DateTimeRange? _selectedDateRange;
 
   AbsencesBloc(this.useCase) : super(AbsencesInitial()) {

--- a/lib/ui/absence/bloc/absence_bloc.dart
+++ b/lib/ui/absence/bloc/absence_bloc.dart
@@ -1,13 +1,18 @@
 import 'package:absence_manager/domain/use_cases/get_absences_with_members_use_case.dart';
 import 'package:absence_manager/ui/absence/bloc/absence_event.dart';
 import 'package:absence_manager/ui/absence/bloc/absence_state.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+/// BLoC responsible for managing the loading, filtering, and pagination of absences.
 class AbsencesBloc extends Bloc<AbsencesEvent, AbsencesState> {
   final GetAbsencesWithMembersUseCase useCase;
 
+  String? _selectedType;
+  DateTimeRange? _selectedDateRange;
+
   AbsencesBloc(this.useCase) : super(AbsencesInitial()) {
-    // Initial load
+    // Handles initial data load (unfiltered)
     on<LoadAbsences>((event, emit) async {
       emit(AbsencesLoading());
       try {
@@ -17,6 +22,8 @@ class AbsencesBloc extends Bloc<AbsencesEvent, AbsencesState> {
             absences: result.absences,
             hasMore: result.absences.length == 10,
             totalCount: result.totalCount,
+            selectedType: _selectedType,
+            selectedDateRange: _selectedDateRange,
           ),
         );
       } catch (e) {
@@ -24,7 +31,47 @@ class AbsencesBloc extends Bloc<AbsencesEvent, AbsencesState> {
       }
     });
 
-    // Load more absences
+    // Handles filtering by type and/or date
+    on<FilterAbsences>((event, emit) async {
+      emit(AbsencesLoading());
+
+      _selectedType = event.type;
+      _selectedDateRange = event.dateRange;
+
+      try {
+        final result = await useCase.execute(offset: 0, limit: 100);
+
+        // Filters absences: keeps only those that match the selected type (if any)
+        // and have both start and end dates within the selected date range (if any)
+        final filtered =
+            result.absences.where((a) {
+              final matchesType = _selectedType == null || a.absence.type == _selectedType;
+              final matchesDate =
+                  _selectedDateRange == null ||
+                  (a.absence.startDate.isAfter(
+                        _selectedDateRange!.start.subtract(const Duration(days: 1)),
+                      ) &&
+                      a.absence.endDate.isBefore(
+                        _selectedDateRange!.end.add(const Duration(days: 1)),
+                      ));
+              return matchesType && matchesDate;
+            }).toList();
+
+        emit(
+          AbsencesLoaded(
+            absences: filtered,
+            hasMore: false,
+            totalCount: result.totalCount,
+            selectedType: _selectedType,
+            selectedDateRange: _selectedDateRange,
+          ),
+        );
+      } catch (e) {
+        emit(AbsencesError(e.toString()));
+      }
+    });
+
+    // Handles pagination of data and applies existing filters to newly fetched results
     on<LoadMoreAbsences>((event, emit) async {
       final currentState = state;
       if (currentState is AbsencesLoaded) {
@@ -32,11 +79,31 @@ class AbsencesBloc extends Bloc<AbsencesEvent, AbsencesState> {
         try {
           final result = await useCase.execute(offset: event.offset, limit: event.limit);
           final hasMore = result.absences.length == event.limit;
+
+          // Merge newly fetched absences with existing ones,
+          // applying current type and date filters to the new items only
+          final combined =
+              currentState.absences +
+              result.absences.where((a) {
+                final matchesType = _selectedType == null || a.absence.type == _selectedType;
+                final matchesDate =
+                    _selectedDateRange == null ||
+                    (a.absence.startDate.isAfter(
+                          _selectedDateRange!.start.subtract(const Duration(days: 1)),
+                        ) &&
+                        a.absence.endDate.isBefore(
+                          _selectedDateRange!.end.add(const Duration(days: 1)),
+                        ));
+                return matchesType && matchesDate;
+              }).toList();
+
           emit(
             AbsencesLoaded(
-              absences: currentState.absences + result.absences,
+              absences: combined,
               hasMore: hasMore,
               totalCount: result.totalCount,
+              selectedType: _selectedType,
+              selectedDateRange: _selectedDateRange,
             ),
           );
         } catch (e) {

--- a/lib/ui/absence/bloc/absence_event.dart
+++ b/lib/ui/absence/bloc/absence_event.dart
@@ -1,3 +1,4 @@
+import 'package:absence_manager/domain/models/absence/absence_type.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
 
@@ -19,7 +20,7 @@ class LoadMoreAbsences extends AbsencesEvent {
 }
 
 class FilterAbsences extends AbsencesEvent {
-  final String? type; // e.g., 'vacation', 'sickness'
+  final AbsenceType? type; // e.g., 'vacation', 'sickness'
   final DateTimeRange? dateRange;
 
   FilterAbsences({this.type, this.dateRange});

--- a/lib/ui/absence/bloc/absence_event.dart
+++ b/lib/ui/absence/bloc/absence_event.dart
@@ -1,4 +1,5 @@
 import 'package:equatable/equatable.dart';
+import 'package:flutter/material.dart';
 
 abstract class AbsencesEvent extends Equatable {
   @override
@@ -15,4 +16,14 @@ class LoadMoreAbsences extends AbsencesEvent {
 
   @override
   List<Object?> get props => [offset, limit];
+}
+
+class FilterAbsences extends AbsencesEvent {
+  final String? type; // e.g., 'vacation', 'sickness'
+  final DateTimeRange? dateRange;
+
+  FilterAbsences({this.type, this.dateRange});
+
+  @override
+  List<Object?> get props => [type, dateRange];
 }

--- a/lib/ui/absence/bloc/absence_state.dart
+++ b/lib/ui/absence/bloc/absence_state.dart
@@ -1,3 +1,4 @@
+import 'package:absence_manager/domain/models/absence/absence_type.dart';
 import 'package:absence_manager/domain/models/absence_with_member.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
@@ -17,7 +18,7 @@ class AbsencesLoaded extends AbsencesState {
   final List<AbsenceWithMember> absences;
   final bool hasMore;
   final int totalCount;
-  final String? selectedType;
+  final AbsenceType? selectedType;
   final DateTimeRange? selectedDateRange;
 
   AbsencesLoaded({

--- a/lib/ui/absence/bloc/absence_state.dart
+++ b/lib/ui/absence/bloc/absence_state.dart
@@ -1,5 +1,6 @@
 import 'package:absence_manager/domain/models/absence_with_member.dart';
 import 'package:equatable/equatable.dart';
+import 'package:flutter/material.dart';
 
 abstract class AbsencesState extends Equatable {
   @override
@@ -16,11 +17,19 @@ class AbsencesLoaded extends AbsencesState {
   final List<AbsenceWithMember> absences;
   final bool hasMore;
   final int totalCount;
+  final String? selectedType;
+  final DateTimeRange? selectedDateRange;
 
-  AbsencesLoaded({required this.absences, required this.hasMore, required this.totalCount});
+  AbsencesLoaded({
+    required this.absences,
+    required this.hasMore,
+    required this.totalCount,
+    this.selectedType,
+    this.selectedDateRange,
+  });
 
   @override
-  List<Object?> get props => [absences, hasMore, totalCount];
+  List<Object?> get props => [absences, hasMore, totalCount, selectedType, selectedDateRange];
 }
 
 class AbsencesError extends AbsencesState {

--- a/lib/ui/absence/widgets/absence_filter_section.dart
+++ b/lib/ui/absence/widgets/absence_filter_section.dart
@@ -1,9 +1,10 @@
+import 'package:absence_manager/domain/models/absence/absence_type.dart';
 import 'package:flutter/material.dart';
 
 class AbsenceFilterSection extends StatelessWidget {
-  final String? selectedType;
+  final AbsenceType? selectedType;
   final DateTimeRange? selectedRange;
-  final void Function(String?) onTypeChanged;
+  final void Function(AbsenceType?) onTypeChanged;
   final void Function(DateTimeRange?) onDateRangeChanged;
 
   const AbsenceFilterSection({
@@ -21,13 +22,14 @@ class AbsenceFilterSection extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          DropdownButtonFormField<String>(
+          DropdownButtonFormField<AbsenceType?>(
             value: selectedType,
             decoration: InputDecoration(labelText: "Type"),
-            items: const [
-              DropdownMenuItem(value: null, child: Text("All")),
-              DropdownMenuItem(value: 'vacation', child: Text("Vacation")),
-              DropdownMenuItem(value: 'sickness', child: Text("Sickness")),
+            items: [
+              const DropdownMenuItem(value: null, child: Text("All")),
+              ...AbsenceType.values.map(
+                (type) => DropdownMenuItem(value: type, child: Text(type.label)),
+              ),
             ],
             onChanged: onTypeChanged,
             isExpanded: true,

--- a/lib/ui/absence/widgets/absence_filter_section.dart
+++ b/lib/ui/absence/widgets/absence_filter_section.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+
+class AbsenceFilterSection extends StatelessWidget {
+  final String? selectedType;
+  final DateTimeRange? selectedRange;
+  final void Function(String?) onTypeChanged;
+  final void Function(DateTimeRange?) onDateRangeChanged;
+
+  const AbsenceFilterSection({
+    super.key,
+    required this.selectedType,
+    required this.selectedRange,
+    required this.onTypeChanged,
+    required this.onDateRangeChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          DropdownButtonFormField<String>(
+            value: selectedType,
+            decoration: InputDecoration(labelText: "Type"),
+            items: const [
+              DropdownMenuItem(value: null, child: Text("All")),
+              DropdownMenuItem(value: 'vacation', child: Text("Vacation")),
+              DropdownMenuItem(value: 'sickness', child: Text("Sickness")),
+            ],
+            onChanged: onTypeChanged,
+            isExpanded: true,
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              Expanded(
+                child: ElevatedButton.icon(
+                  onPressed: () async {
+                    final now = DateTime.now();
+                    final picked = await showDateRangePicker(
+                      context: context,
+                      firstDate: DateTime(now.year - 5),
+                      lastDate: DateTime(now.year + 5),
+                      initialDateRange: selectedRange,
+                    );
+                    if (picked != null) {
+                      onDateRangeChanged(picked);
+                    }
+                  },
+                  icon: const Icon(Icons.date_range),
+                  label: Text(
+                    selectedRange == null
+                        ? "Select Date Range"
+                        : "${selectedRange?.start.toLocal().toShortString()} → ${selectedRange?.end.toLocal().toShortString()}",
+                  ),
+                ),
+              ),
+              if (selectedRange != null)
+                Padding(
+                  padding: const EdgeInsets.only(left: 8),
+                  child: TextButton.icon(
+                    onPressed: () => onDateRangeChanged(null),
+                    icon: const Icon(Icons.clear),
+                    label: const Text("Clear"),
+                  ),
+                ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+extension on DateTime {
+  String toShortString() =>
+      "${day.toString().padLeft(2, '0')}/${month.toString().padLeft(2, '0')}/$year";
+}

--- a/lib/ui/absence/widgets/absence_screen.dart
+++ b/lib/ui/absence/widgets/absence_screen.dart
@@ -1,6 +1,7 @@
 import 'package:absence_manager/ui/absence/bloc/absence_bloc.dart';
 import 'package:absence_manager/ui/absence/bloc/absence_event.dart';
 import 'package:absence_manager/ui/absence/bloc/absence_state.dart';
+import 'package:absence_manager/ui/absence/widgets/absence_filter_section.dart';
 import 'package:absence_manager/ui/absence/widgets/absences_list.dart';
 import 'package:absence_manager/ui/absence/widgets/absences_summary.dart';
 import 'package:flutter/material.dart';
@@ -29,6 +30,20 @@ class AbsencesScreen extends StatelessWidget {
                 AbsencesSummary(
                   totalAbsences: state.totalCount,
                   fetchedAbsences: state.absences.length,
+                ),
+                AbsenceFilterSection(
+                  selectedType: state.selectedType,
+                  selectedRange: state.selectedDateRange,
+                  onTypeChanged: (type) {
+                    context.read<AbsencesBloc>().add(
+                      FilterAbsences(type: type, dateRange: state.selectedDateRange),
+                    );
+                  },
+                  onDateRangeChanged: (range) {
+                    context.read<AbsencesBloc>().add(
+                      FilterAbsences(type: state.selectedType, dateRange: range),
+                    );
+                  },
                 ),
                 Expanded(
                   child: AbsencesList(

--- a/lib/ui/absence/widgets/absence_tile.dart
+++ b/lib/ui/absence/widgets/absence_tile.dart
@@ -1,3 +1,4 @@
+import 'package:absence_manager/domain/models/absence/absence_type.dart';
 import 'package:absence_manager/domain/models/absence_with_member.dart';
 import 'package:flutter/material.dart';
 
@@ -22,7 +23,7 @@ class AbsenceTile extends StatelessWidget {
       subtitle: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text("Type: ${absence.type}"),
+          Text("Type: ${absence.type.label}"),
           Text("Period: ${_formatDate(absence.startDate)} → ${_formatDate(absence.endDate)}"),
           if (absence.memberNote?.isNotEmpty ?? false) Text("Member note: ${absence.memberNote}"),
           if (absence.admitterNote?.isNotEmpty ?? false)

--- a/test/domain/usecases/get_absences_with_members_use_case_test.dart
+++ b/test/domain/usecases/get_absences_with_members_use_case_test.dart
@@ -2,6 +2,7 @@ import 'package:absence_manager/data/repositories/absence/absence_repository.dar
 import 'package:absence_manager/data/repositories/member/member_repository.dart';
 import 'package:absence_manager/domain/models/absence/absence.dart';
 import 'package:absence_manager/domain/models/absence/absence_list.dart';
+import 'package:absence_manager/domain/models/absence/absence_type.dart';
 import 'package:absence_manager/domain/models/absence_with_member.dart';
 import 'package:absence_manager/domain/models/member/member.dart';
 import 'package:absence_manager/domain/use_cases/get_absences_with_members_use_case.dart';
@@ -29,7 +30,7 @@ void main() {
         Absence(
           id: 1,
           userId: 101,
-          type: "vacation",
+          type: AbsenceType.vacation,
           startDate: DateTime(2021, 1, 1),
           endDate: DateTime(2021, 1, 5),
           memberNote: "Ski trip",
@@ -39,7 +40,7 @@ void main() {
         Absence(
           id: 2,
           userId: 101,
-          type: "vacation",
+          type: AbsenceType.vacation,
           startDate: DateTime(2021, 1, 6),
           endDate: DateTime(2021, 1, 10),
           memberNote: "Ski trip",
@@ -71,7 +72,7 @@ void main() {
         Absence(
           id: 1,
           userId: 999,
-          type: "vacation",
+          type: AbsenceType.vacation,
           startDate: DateTime(2021, 1, 1),
           endDate: DateTime(2021, 1, 5),
           memberNote: "Unknown trip",


### PR DESCRIPTION
This PR includes:

- Added filtering by **absence type** and **date range**
- Replaced raw strings (`'vacation'`, `'sickness'`) with a new `AbsenceType` enum for better type safety and maintainability

These changes improve both the UX (by enabling filtering) and the code structure (by removing string-based type logic).