### PR TITLE
Refactor iCal Exporter for Testability and Add Unit Tests

### DIFF
--- a/lib/util/i_cal_exporter.dart
+++ b/lib/util/i_cal_exporter.dart
@@ -5,15 +5,15 @@ import 'package:absence_manager/domain/models/absence_with_member.dart';
 import 'package:path_provider/path_provider.dart';
 
 class ICalExporter {
-  /// Generates an .ics file containing the given [absences]
-  /// and saves it in the app's documents directory.
-  /// Returns the generated file.
-  static Future<File> generateICalFile(List<AbsenceWithMember> absences) async {
+  /// Builds the iCal content string (without writing to file).
+  static String buildICalContent(List<AbsenceWithMember> absences, {DateTime? now}) {
     final buffer =
         StringBuffer()
           ..writeln('BEGIN:VCALENDAR')
           ..writeln('VERSION:2.0')
           ..writeln('PRODID:-//Crewmeister Absence Manager//EN');
+
+    final timestamp = _formatDateTime((now ?? DateTime.now()).toUtc());
 
     for (final entry in absences) {
       final absence = entry.absence;
@@ -24,7 +24,7 @@ class ICalExporter {
       buffer
         ..writeln('BEGIN:VEVENT')
         ..writeln('UID:${absence.id}-${member.userId}@crewmeister')
-        ..writeln('DTSTAMP:${_formatDateTime(DateTime.now())}')
+        ..writeln('DTSTAMP:$timestamp')
         ..writeln('DTSTART;VALUE=DATE:${_formatDate(absence.startDate!)}')
         ..writeln('DTEND;VALUE=DATE:${_formatDate(absence.endDate!.add(const Duration(days: 1)))}')
         ..writeln('SUMMARY:${member.name} - ${absence.type?.label}')
@@ -38,27 +38,28 @@ class ICalExporter {
     }
 
     buffer.writeln('END:VCALENDAR');
+    return buffer.toString();
+  }
 
+  /// Writes the iCal file to disk (used in production).
+  static Future<File> generateICalFile(List<AbsenceWithMember> absences) async {
     final directory = await getApplicationDocumentsDirectory();
     final file = File('${directory.path}/absences_${DateTime.now().millisecondsSinceEpoch}.ics');
-    await file.writeAsString(buffer.toString());
-
+    final content = buildICalContent(absences);
+    await file.writeAsString(content);
     return file;
   }
 
-  /// Formats a date as YYYYMMDD (iCal all-day event format).
   static String _formatDate(DateTime date) {
     return '${date.year.toString().padLeft(4, '0')}'
         '${date.month.toString().padLeft(2, '0')}'
         '${date.day.toString().padLeft(2, '0')}';
   }
 
-  /// Formats a timestamp as YYYYMMDDTHHMMSSZ (iCal timestamp format).
   static String _formatDateTime(DateTime dateTime) {
-    final utc = dateTime.toUtc();
-    return '${_formatDate(utc)}T'
-        '${utc.hour.toString().padLeft(2, '0')}'
-        '${utc.minute.toString().padLeft(2, '0')}'
-        '${utc.second.toString().padLeft(2, '0')}Z';
+    return '${_formatDate(dateTime)}T'
+        '${dateTime.hour.toString().padLeft(2, '0')}'
+        '${dateTime.minute.toString().padLeft(2, '0')}'
+        '${dateTime.second.toString().padLeft(2, '0')}Z';
   }
 }

--- a/test/utils/ical_exporter_test.dart
+++ b/test/utils/ical_exporter_test.dart
@@ -1,0 +1,85 @@
+import 'package:absence_manager/domain/models/absence/absence.dart';
+import 'package:absence_manager/domain/models/absence/absence_type.dart';
+import 'package:absence_manager/domain/models/absence_with_member.dart';
+import 'package:absence_manager/domain/models/member/member.dart';
+import 'package:absence_manager/util/i_cal_exporter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ICalExporter.buildICalContent', () {
+    test('generates correct iCal string for one valid absence', () {
+      // Arrange
+      final fixedNow = DateTime.utc(2024, 4, 1, 10, 30, 0);
+      final absences = [
+        AbsenceWithMember(
+          absence: Absence(
+            id: 1,
+            userId: 10,
+            type: AbsenceType.vacation,
+            status: AbsenceStatus.confirmed,
+            startDate: DateTime(2024, 4, 10),
+            endDate: DateTime(2024, 4, 12),
+            memberNote: 'Family trip',
+            admitterNote: null,
+          ),
+          member: Member(userId: 10, name: 'John Doe', imageUrl: ''),
+        ),
+      ];
+
+      // Act
+      final result = ICalExporter.buildICalContent(absences, now: fixedNow);
+
+      // Assert
+      expect(result, contains('BEGIN:VCALENDAR'));
+      expect(result, contains('END:VCALENDAR'));
+      expect(result, contains('BEGIN:VEVENT'));
+      expect(result, contains('END:VEVENT'));
+      expect(result, contains('UID:1-10@crewmeister'));
+      expect(result, contains('DTSTAMP:20240401T103000Z'));
+      expect(result, contains('DTSTART;VALUE=DATE:20240410'));
+      expect(result, contains('DTEND;VALUE=DATE:20240413'));
+      expect(result, contains('SUMMARY:John Doe - Vacation'));
+      expect(result, contains('STATUS:CONFIRMED'));
+      expect(result, contains('DESCRIPTION:Family trip'));
+    });
+
+    test('skips absences with null start or end dates', () {
+      final absences = [
+        AbsenceWithMember(
+          absence: Absence(
+            id: 2,
+            userId: 11,
+            type: AbsenceType.sickness,
+            status: AbsenceStatus.requested,
+            startDate: null,
+            endDate: DateTime(2024, 4, 10),
+          ),
+          member: Member(userId: 11, name: 'Jane Doe', imageUrl: ''),
+        ),
+        AbsenceWithMember(
+          absence: Absence(
+            id: 3,
+            userId: 12,
+            type: AbsenceType.vacation,
+            status: AbsenceStatus.rejected,
+            startDate: DateTime(2024, 4, 10),
+            endDate: null,
+          ),
+          member: Member(userId: 12, name: 'Alex Turner', imageUrl: ''),
+        ),
+      ];
+
+      final result = ICalExporter.buildICalContent(absences);
+      expect(result.contains('BEGIN:VEVENT'), isFalse);
+      expect(result.contains('SUMMARY:'), isFalse);
+    });
+
+    test('generates empty calendar for empty absence list', () {
+      final result = ICalExporter.buildICalContent([]);
+      expect(result.contains('BEGIN:VEVENT'), isFalse);
+      expect(result.contains('END:VEVENT'), isFalse);
+      expect(result.contains('BEGIN:VCALENDAR'), isTrue);
+      expect(result.contains('END:VCALENDAR'), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
This PR improves the testability of the `ICalExporter` by separating pure logic from file system operations. The iCal content generation is now handled by a dedicated `buildICalContent` method, which returns a `.ics` string based on the input absences.

---

### ✅ What's Included:

- **Refactored `ICalExporter`:**
  - Extracted pure logic into `buildICalContent`
  - Accepts an optional `now` parameter to make `DTSTAMP` deterministic in tests
  - Retained `generateICalFile` for production file writing

- **New Unit Tests for `buildICalContent`:**
  - Generates correct iCal content for a valid absence
  - Skips absences with missing start or end dates
  - Produces a valid calendar structure for empty input
