### PR TITLE
Add platform-specific AbsenceExporter with web/mobile support and UI refactor

### DIFF
--- a/lib/config/service_locator.dart
+++ b/lib/config/service_locator.dart
@@ -9,6 +9,7 @@ import 'package:absence_manager/data/services/local/local_json_loader.dart';
 import 'package:absence_manager/data/services/local/local_member_service.dart';
 import 'package:absence_manager/domain/use_cases/get_absences_with_members_use_case.dart';
 import 'package:absence_manager/ui/absence/bloc/absence_bloc.dart';
+import 'package:absence_manager/util/i_cal_exporter_factory.dart';
 import 'package:get_it/get_it.dart';
 
 final sl = GetIt.instance;
@@ -31,5 +32,5 @@ Future<void> setupLocator() async {
   );
 
   //Bloc
-  sl.registerFactory(() => AbsencesBloc(sl()));
+  sl.registerFactory(() => AbsencesBloc(sl(), createAbsenceExporter()));
 }

--- a/lib/data/services/export/mobile_absence_i_cal_exporter.dart
+++ b/lib/data/services/export/mobile_absence_i_cal_exporter.dart
@@ -1,0 +1,14 @@
+import 'package:absence_manager/domain/models/absence_with_member.dart';
+import 'package:absence_manager/domain/use_cases/absence_i_cal_exporter.dart';
+import 'package:absence_manager/util/i_cal_exporter.dart';
+import 'package:share_plus/share_plus.dart';
+
+AbsenceICalExporter createAbsenceExporter() => MobileAbsenceICalExporter();
+
+class MobileAbsenceICalExporter implements AbsenceICalExporter {
+  @override
+  Future<void> export(List<AbsenceWithMember> absences) async {
+    final file = await ICalExporter.generateICalFile(absences);
+    await Share.shareXFiles([XFile(file.path)], text: 'Absence calendar export');
+  }
+}

--- a/lib/data/services/export/mobile_absence_i_cal_exporter.dart
+++ b/lib/data/services/export/mobile_absence_i_cal_exporter.dart
@@ -3,6 +3,10 @@ import 'package:absence_manager/domain/use_cases/absence_i_cal_exporter.dart';
 import 'package:absence_manager/util/i_cal_exporter.dart';
 import 'package:share_plus/share_plus.dart';
 
+/// Mobile implementation of [AbsenceExporter].
+///
+/// Generates a local .ics file and shares it using the `share_plus` plugin.
+
 AbsenceICalExporter createAbsenceExporter() => MobileAbsenceICalExporter();
 
 class MobileAbsenceICalExporter implements AbsenceICalExporter {

--- a/lib/data/services/export/mobile_absence_i_cal_exporter.dart
+++ b/lib/data/services/export/mobile_absence_i_cal_exporter.dart
@@ -13,6 +13,6 @@ class MobileAbsenceICalExporter implements AbsenceICalExporter {
   @override
   Future<void> export(List<AbsenceWithMember> absences) async {
     final file = await ICalExporter.generateICalFile(absences);
-    await Share.shareXFiles([XFile(file.path)], text: 'Absence calendar export');
+    await Share.shareXFiles([XFile(file.path)]);
   }
 }

--- a/lib/data/services/export/stub_absence_i_cal_exporter.dart
+++ b/lib/data/services/export/stub_absence_i_cal_exporter.dart
@@ -1,0 +1,11 @@
+import 'package:absence_manager/domain/models/absence_with_member.dart';
+import 'package:absence_manager/domain/use_cases/absence_i_cal_exporter.dart';
+
+AbsenceICalExporter createAbsenceExporter() => StubAbsenceICalExporter();
+
+class StubAbsenceICalExporter implements AbsenceICalExporter {
+  @override
+  Future<void> export(List<AbsenceWithMember> absences) {
+    throw UnsupportedError('Platform not supported');
+  }
+}

--- a/lib/data/services/export/stub_absence_i_cal_exporter.dart
+++ b/lib/data/services/export/stub_absence_i_cal_exporter.dart
@@ -1,6 +1,10 @@
 import 'package:absence_manager/domain/models/absence_with_member.dart';
 import 'package:absence_manager/domain/use_cases/absence_i_cal_exporter.dart';
 
+/// Fallback implementation of [AbsenceExporter] for unsupported platforms.
+///
+/// Throws an [UnsupportedError] with a detailed message when `export()` is called./
+
 AbsenceICalExporter createAbsenceExporter() => StubAbsenceICalExporter();
 
 class StubAbsenceICalExporter implements AbsenceICalExporter {

--- a/lib/data/services/export/web_absence_i_cal_exporter.dart
+++ b/lib/data/services/export/web_absence_i_cal_exporter.dart
@@ -4,6 +4,10 @@ import 'package:absence_manager/domain/models/absence_with_member.dart';
 import 'package:absence_manager/domain/use_cases/absence_i_cal_exporter.dart';
 import 'package:absence_manager/util/i_cal_exporter.dart';
 
+/// Web implementation of [AbsenceExporter].
+///
+/// Uses [AnchorElement] and [Blob] to trigger a browser download of the generated .ics file.
+
 AbsenceICalExporter createAbsenceExporter() => WebAbsenceICalExporter();
 
 class WebAbsenceICalExporter implements AbsenceICalExporter {

--- a/lib/data/services/export/web_absence_i_cal_exporter.dart
+++ b/lib/data/services/export/web_absence_i_cal_exporter.dart
@@ -1,0 +1,21 @@
+import 'dart:html' as html;
+
+import 'package:absence_manager/domain/models/absence_with_member.dart';
+import 'package:absence_manager/domain/use_cases/absence_i_cal_exporter.dart';
+import 'package:absence_manager/util/i_cal_exporter.dart';
+
+AbsenceICalExporter createAbsenceExporter() => WebAbsenceICalExporter();
+
+class WebAbsenceICalExporter implements AbsenceICalExporter {
+  @override
+  Future<void> export(List<AbsenceWithMember> absences) async {
+    final content = ICalExporter.buildICalContent(absences);
+    final blob = html.Blob([content], 'text/calendar');
+    final url = html.Url.createObjectUrlFromBlob(blob);
+    final anchor =
+        html.AnchorElement(href: url)
+          ..setAttribute('download', 'absences.ics')
+          ..click();
+    html.Url.revokeObjectUrl(url);
+  }
+}

--- a/lib/data/services/export/web_absence_i_cal_exporter.dart
+++ b/lib/data/services/export/web_absence_i_cal_exporter.dart
@@ -1,8 +1,7 @@
-import 'dart:html' as html;
-
 import 'package:absence_manager/domain/models/absence_with_member.dart';
 import 'package:absence_manager/domain/use_cases/absence_i_cal_exporter.dart';
 import 'package:absence_manager/util/i_cal_exporter.dart';
+import 'package:universal_html/html.dart' as html;
 
 /// Web implementation of [AbsenceExporter].
 ///
@@ -16,10 +15,13 @@ class WebAbsenceICalExporter implements AbsenceICalExporter {
     final content = ICalExporter.buildICalContent(absences);
     final blob = html.Blob([content], 'text/calendar');
     final url = html.Url.createObjectUrlFromBlob(blob);
-    final anchor =
-        html.AnchorElement(href: url)
-          ..setAttribute('download', 'absences.ics')
-          ..click();
+
+    html.AnchorElement()
+      ..href = url
+      ..setAttribute('download', 'absences.ics')
+      ..click();
+
+    // Clean up
     html.Url.revokeObjectUrl(url);
   }
 }

--- a/lib/domain/use_cases/absence_i_cal_exporter.dart
+++ b/lib/domain/use_cases/absence_i_cal_exporter.dart
@@ -1,0 +1,5 @@
+import 'package:absence_manager/domain/models/absence_with_member.dart';
+
+abstract class AbsenceICalExporter {
+  Future<void> export(List<AbsenceWithMember> absences);
+}

--- a/lib/domain/use_cases/absence_i_cal_exporter.dart
+++ b/lib/domain/use_cases/absence_i_cal_exporter.dart
@@ -1,5 +1,7 @@
 import 'package:absence_manager/domain/models/absence_with_member.dart';
 
+/// Contract for exporting absences to a platform-specific destination (e.g., file, browser download).
+/// This interface is implemented separately for web, mobile, and stub platforms.
 abstract class AbsenceICalExporter {
   Future<void> export(List<AbsenceWithMember> absences);
 }

--- a/lib/ui/absence/bloc/absence_bloc.dart
+++ b/lib/ui/absence/bloc/absence_bloc.dart
@@ -16,7 +16,7 @@ class AbsencesBloc extends Bloc<AbsencesEvent, AbsencesState> {
   DateTimeRange? _selectedDateRange;
 
   AbsencesBloc(this.useCase, this.exporter) : super(AbsencesInitial()) {
-    // Handles initial data load (unfiltered)
+    /// Handles initial data load (unfiltered)
     on<LoadAbsences>((event, emit) async {
       emit(AbsencesLoading());
       try {
@@ -32,7 +32,7 @@ class AbsencesBloc extends Bloc<AbsencesEvent, AbsencesState> {
       }
     });
 
-    // Handles filtering by type and/or date
+    /// Handles filtering by type and/or date
     on<FilterAbsences>((event, emit) async {
       emit(AbsencesLoading());
 
@@ -49,7 +49,7 @@ class AbsencesBloc extends Bloc<AbsencesEvent, AbsencesState> {
       }
     });
 
-    // Handles pagination of data and applies existing filters to newly fetched results
+    /// Handles pagination of data and applies existing filters to newly fetched results
     on<LoadMoreAbsences>((event, emit) async {
       final currentState = state;
       if (currentState is AbsencesLoaded) {
@@ -71,6 +71,9 @@ class AbsencesBloc extends Bloc<AbsencesEvent, AbsencesState> {
       }
     });
 
+    /// Handles exporting absences to iCal using the injected [AbsenceExporter].
+    /// Emits `isExporting: true` while the export is in progress.
+    /// On completion, emits `isExporting: false` and triggers [onExportResult] callback.
     on<ExportAbsencesToICal>((event, emit) async {
       final currentState = state;
       if (currentState is AbsencesLoaded) {

--- a/lib/ui/absence/bloc/absence_bloc.dart
+++ b/lib/ui/absence/bloc/absence_bloc.dart
@@ -1,20 +1,21 @@
 import 'package:absence_manager/domain/models/absence/absence_type.dart';
 import 'package:absence_manager/domain/models/absence_with_member.dart';
+import 'package:absence_manager/domain/use_cases/absence_i_cal_exporter.dart';
 import 'package:absence_manager/domain/use_cases/get_absences_with_members_use_case.dart';
 import 'package:absence_manager/ui/absence/bloc/absence_event.dart';
 import 'package:absence_manager/ui/absence/bloc/absence_state.dart';
-import 'package:absence_manager/util/i_cal_exporter.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 /// BLoC responsible for managing the loading, filtering, and pagination of absences.
 class AbsencesBloc extends Bloc<AbsencesEvent, AbsencesState> {
   final GetAbsencesWithMembersUseCase useCase;
+  final AbsenceICalExporter exporter;
 
   AbsenceType? _selectedType;
   DateTimeRange? _selectedDateRange;
 
-  AbsencesBloc(this.useCase) : super(AbsencesInitial()) {
+  AbsencesBloc(this.useCase, this.exporter) : super(AbsencesInitial()) {
     // Handles initial data load (unfiltered)
     on<LoadAbsences>((event, emit) async {
       emit(AbsencesLoading());
@@ -76,14 +77,12 @@ class AbsencesBloc extends Bloc<AbsencesEvent, AbsencesState> {
         emit(currentState.copyWith(isExporting: true));
 
         try {
-          final file = await ICalExporter.generateICalFile(currentState.absences);
+          await exporter.export(currentState.absences);
           emit(currentState.copyWith(isExporting: false));
-
-          event.onExportSuccess?.call(file.path);
+          event.onExportResult?.call("Data exported successfully");
         } catch (e) {
           emit(currentState.copyWith(isExporting: false));
-
-          event.onExportError?.call('Export failed: ${e.toString()}');
+          event.onExportResult?.call('Export failed: ${e.toString()}');
         }
       }
     });

--- a/lib/ui/absence/bloc/absence_event.dart
+++ b/lib/ui/absence/bloc/absence_event.dart
@@ -30,10 +30,9 @@ class FilterAbsences extends AbsencesEvent {
 }
 
 class ExportAbsencesToICal extends AbsencesEvent {
-  final void Function(String filePath)? onExportSuccess;
-  final void Function(String error)? onExportError;
+  final void Function(String message)? onExportResult;
 
-  ExportAbsencesToICal({this.onExportSuccess, this.onExportError});
+  ExportAbsencesToICal({this.onExportResult});
 
   @override
   List<Object?> get props => [];

--- a/lib/ui/absence/widgets/absence_screen.dart
+++ b/lib/ui/absence/widgets/absence_screen.dart
@@ -4,7 +4,6 @@ import 'package:absence_manager/ui/absence/bloc/absence_state.dart';
 import 'package:absence_manager/ui/absence/widgets/absences_screen_body.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:share_plus/share_plus.dart';
 
 class AbsencesScreen extends StatelessWidget {
   const AbsencesScreen({super.key});
@@ -24,12 +23,10 @@ class AbsencesScreen extends StatelessWidget {
                     ? () {
                       context.read<AbsencesBloc>().add(
                         ExportAbsencesToICal(
-                          onExportSuccess: (filePath) => Share.shareXFiles([XFile(filePath)]),
-                          onExportError: (error) {
-                            ScaffoldMessenger.of(
-                              context,
-                            ).showSnackBar(SnackBar(content: Text(error)));
-                          },
+                          onExportResult:
+                              (message) => ScaffoldMessenger.of(
+                                context,
+                              ).showSnackBar(SnackBar(content: Text(message))),
                         ),
                       );
                     }

--- a/lib/ui/absence/widgets/absence_screen.dart
+++ b/lib/ui/absence/widgets/absence_screen.dart
@@ -1,7 +1,7 @@
 import 'package:absence_manager/ui/absence/bloc/absence_bloc.dart';
-import 'package:absence_manager/ui/absence/bloc/absence_event.dart';
 import 'package:absence_manager/ui/absence/bloc/absence_state.dart';
 import 'package:absence_manager/ui/absence/widgets/absences_screen_body.dart';
+import 'package:absence_manager/ui/absence/widgets/export_fab_button.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -12,34 +12,7 @@ class AbsencesScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: Text("Absences")),
-      floatingActionButton: BlocBuilder<AbsencesBloc, AbsencesState>(
-        builder: (context, state) {
-          final bool isEnabled = state is AbsencesLoaded && state.absences.isNotEmpty;
-          final colorScheme = Theme.of(context).colorScheme;
-
-          return FloatingActionButton(
-            onPressed:
-                isEnabled
-                    ? () {
-                      context.read<AbsencesBloc>().add(
-                        ExportAbsencesToICal(
-                          onExportResult:
-                              (message) => ScaffoldMessenger.of(
-                                context,
-                              ).showSnackBar(SnackBar(content: Text(message))),
-                        ),
-                      );
-                    }
-                    : null,
-            backgroundColor:
-                isEnabled ? colorScheme.primaryContainer : colorScheme.primaryContainer,
-            child: Icon(
-              Icons.share,
-              color: isEnabled ? colorScheme.primary : colorScheme.primary.withValues(alpha: 0.3),
-            ),
-          );
-        },
-      ),
+      floatingActionButton: ExportFabButton(),
       body: BlocBuilder<AbsencesBloc, AbsencesState>(
         builder: (context, state) {
           if (state is AbsencesLoading) {

--- a/lib/ui/absence/widgets/export_fab_button.dart
+++ b/lib/ui/absence/widgets/export_fab_button.dart
@@ -1,0 +1,44 @@
+import 'package:absence_manager/ui/absence/bloc/absence_bloc.dart';
+import 'package:absence_manager/ui/absence/bloc/absence_event.dart';
+import 'package:absence_manager/ui/absence/bloc/absence_state.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class ExportFabButton extends StatelessWidget {
+  const ExportFabButton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<AbsencesBloc, AbsencesState>(
+      builder: (context, state) {
+        final bool isEnabled = state is AbsencesLoaded && state.absences.isNotEmpty;
+        final colorScheme = Theme.of(context).colorScheme;
+
+        final backgroundColor =
+            isEnabled ? colorScheme.primaryContainer : colorScheme.primaryContainer;
+        final icon = kIsWeb ? Icons.download : Icons.share;
+        final iconColor =
+            isEnabled ? colorScheme.primary : colorScheme.primary.withValues(alpha: 0.3);
+
+        return FloatingActionButton(
+          onPressed:
+              isEnabled
+                  ? () {
+                    context.read<AbsencesBloc>().add(
+                      ExportAbsencesToICal(
+                        onExportResult:
+                            (message) => ScaffoldMessenger.of(
+                              context,
+                            ).showSnackBar(SnackBar(content: Text(message))),
+                      ),
+                    );
+                  }
+                  : null,
+          backgroundColor: backgroundColor,
+          child: Icon(icon, color: iconColor),
+        );
+      },
+    );
+  }
+}

--- a/lib/util/i_cal_exporter_factory.dart
+++ b/lib/util/i_cal_exporter_factory.dart
@@ -1,0 +1,3 @@
+export 'package:absence_manager/data/services/export/stub_absence_i_cal_exporter.dart'
+    if (dart.library.html) 'package:absence_manager/data/services/export/web_absence_i_cal_exporter.dart'
+    if (dart.library.io) 'package:absence_manager/data/services/export/mobile_absence_i_cal_exporter.dart';

--- a/lib/util/i_cal_exporter_factory.dart
+++ b/lib/util/i_cal_exporter_factory.dart
@@ -1,3 +1,11 @@
 export 'package:absence_manager/data/services/export/stub_absence_i_cal_exporter.dart'
     if (dart.library.html) 'package:absence_manager/data/services/export/web_absence_i_cal_exporter.dart'
     if (dart.library.io) 'package:absence_manager/data/services/export/mobile_absence_i_cal_exporter.dart';
+
+/// Conditionally exports the platform-specific implementation of [AbsenceExporter].
+///
+/// - On Web: uses [WebAbsenceICalExporter] to trigger browser file download
+/// - On Mobile/Desktop: uses [MobileAbsenceICalExporter] to generate and share a file
+/// - Fallback: uses [StubAbsenceICalExporter] which throws an error for unsupported platforms
+///
+/// This allows the app to inject the correct exporter without platform checks in the BLoC or UI.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,9 @@ dependencies:
   path_provider: ^2.1.5
   share_plus: ^10.1.4
 
+  # Replacement for deprecated dart:html - provides web APIs that work across all platforms
+  universal_html: ^2.2.4
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/test/ui/absences_screen/bloc/absences_bloc_test.mocks.dart
+++ b/test/ui/absences_screen/bloc/absences_bloc_test.mocks.dart
@@ -5,14 +5,12 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i6;
 
-import 'package:absence_manager/data/repositories/absence/absence_repository.dart'
-    as _i2;
-import 'package:absence_manager/data/repositories/member/member_repository.dart'
-    as _i3;
-import 'package:absence_manager/domain/models/absence_list_with_members.dart'
-    as _i4;
-import 'package:absence_manager/domain/use_cases/get_absences_with_members_use_case.dart'
-    as _i5;
+import 'package:absence_manager/data/repositories/absence/absence_repository.dart' as _i2;
+import 'package:absence_manager/data/repositories/member/member_repository.dart' as _i3;
+import 'package:absence_manager/domain/models/absence_list_with_members.dart' as _i4;
+import 'package:absence_manager/domain/models/absence_with_member.dart' as _i8;
+import 'package:absence_manager/domain/use_cases/absence_i_cal_exporter.dart' as _i7;
+import 'package:absence_manager/domain/use_cases/get_absences_with_members_use_case.dart' as _i5;
 import 'package:mockito/mockito.dart' as _i1;
 
 // ignore_for_file: type=lint
@@ -29,20 +27,17 @@ import 'package:mockito/mockito.dart' as _i1;
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
 
-class _FakeAbsenceRepository_0 extends _i1.SmartFake
-    implements _i2.AbsenceRepository {
+class _FakeAbsenceRepository_0 extends _i1.SmartFake implements _i2.AbsenceRepository {
   _FakeAbsenceRepository_0(Object parent, Invocation parentInvocation)
     : super(parent, parentInvocation);
 }
 
-class _FakeMemberRepository_1 extends _i1.SmartFake
-    implements _i3.MemberRepository {
+class _FakeMemberRepository_1 extends _i1.SmartFake implements _i3.MemberRepository {
   _FakeMemberRepository_1(Object parent, Invocation parentInvocation)
     : super(parent, parentInvocation);
 }
 
-class _FakeAbsenceListWithMembers_2 extends _i1.SmartFake
-    implements _i4.AbsenceListWithMembers {
+class _FakeAbsenceListWithMembers_2 extends _i1.SmartFake implements _i4.AbsenceListWithMembers {
   _FakeAbsenceListWithMembers_2(Object parent, Invocation parentInvocation)
     : super(parent, parentInvocation);
 }
@@ -60,10 +55,7 @@ class MockGetAbsencesWithMembersUseCase extends _i1.Mock
   _i2.AbsenceRepository get absenceRepo =>
       (super.noSuchMethod(
             Invocation.getter(#absenceRepo),
-            returnValue: _FakeAbsenceRepository_0(
-              this,
-              Invocation.getter(#absenceRepo),
-            ),
+            returnValue: _FakeAbsenceRepository_0(this, Invocation.getter(#absenceRepo)),
           )
           as _i2.AbsenceRepository);
 
@@ -71,29 +63,38 @@ class MockGetAbsencesWithMembersUseCase extends _i1.Mock
   _i3.MemberRepository get memberRepo =>
       (super.noSuchMethod(
             Invocation.getter(#memberRepo),
-            returnValue: _FakeMemberRepository_1(
-              this,
-              Invocation.getter(#memberRepo),
-            ),
+            returnValue: _FakeMemberRepository_1(this, Invocation.getter(#memberRepo)),
           )
           as _i3.MemberRepository);
 
   @override
-  _i6.Future<_i4.AbsenceListWithMembers> execute({
-    int? offset = 0,
-    int? limit = 10,
-  }) =>
+  _i6.Future<_i4.AbsenceListWithMembers> execute({int? offset = 0, int? limit = 10}) =>
       (super.noSuchMethod(
             Invocation.method(#execute, [], {#offset: offset, #limit: limit}),
             returnValue: _i6.Future<_i4.AbsenceListWithMembers>.value(
               _FakeAbsenceListWithMembers_2(
                 this,
-                Invocation.method(#execute, [], {
-                  #offset: offset,
-                  #limit: limit,
-                }),
+                Invocation.method(#execute, [], {#offset: offset, #limit: limit}),
               ),
             ),
           )
           as _i6.Future<_i4.AbsenceListWithMembers>);
+}
+
+/// A class which mocks [AbsenceExporter].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockAbsenceExporter extends _i1.Mock implements _i7.AbsenceICalExporter {
+  MockAbsenceExporter() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i6.Future<void> export(List<_i8.AbsenceWithMember>? absences) =>
+      (super.noSuchMethod(
+            Invocation.method(#export, [absences]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
 }


### PR DESCRIPTION
This pull request introduces a complete iCal export solution for absences, with full platform-specific support and a UI-level improvement.

---

### ✅ Features & Architecture

- **Added `AbsenceExporter` interface** in the domain layer to abstract iCal exporting
- **Implemented platform-specific exporters:**
  - `WebAbsenceICalExporter`: triggers browser download via Blob and AnchorElement (using `package:web`)
  - `MobileAbsenceICalExporter`: shares `.ics` file using `share_plus`
  - `StubAbsenceICalExporter`: fallback implementation that throws `UnsupportedError` on unsupported platforms
- **Factory resolver**: Added `createAbsenceExporter()` using Dart conditional imports to dynamically load the correct implementation based on platform

---

### 🔧 Refactors

- **Updated `AbsencesBloc`** to inject the `AbsenceExporter`, keeping platform logic out of the BLoC
- **Created `ExportFabButton` widget** to extract and simplify floating action button logic:
  - Handles platform-specific icon (`Icons.download` on Web, `Icons.share` on Mobile)
  - Manages enable/disable state, color, and result feedback internally

---

### 🧪 Tests

- Added `blocTest` coverage for the new `ExportAbsencesToICal` event
- Verified:
  - `isExporting` state transitions
  - Exporter invocation
  - Success callback message behavior


