### PR TITLE
handle offline filtering & pagination and prevent duplicate data

### DIFF
--- a/lib/data/services/api/member_remote_service.dart
+++ b/lib/data/services/api/member_remote_service.dart
@@ -8,7 +8,7 @@ class MemberRemoteService {
   MemberRemoteService(this._httpClient);
 
   Future<List<MemberApiModel>> fetchMembers() async {
-    final data = await _httpClient.get(ApiConfig.absences);
+    final data = await _httpClient.get(ApiConfig.members);
 
     if (data is List) {
       return data.map((json) => MemberApiModel.fromJson(json)).toList();

--- a/lib/data/services/local/absence_local_service.dart
+++ b/lib/data/services/local/absence_local_service.dart
@@ -4,13 +4,18 @@ import 'package:hive/hive.dart';
 class AbsenceLocalService {
   static const String _boxName = 'absence_cache';
 
+  /// Save absences by using their unique ID as Hive key (avoids duplication)
   Future<void> saveAbsences(List<AbsenceCacheModel> absences) async {
     final box = await Hive.openBox<AbsenceCacheModel>(_boxName);
-    await box.clear();
-    await box.addAll(absences);
+    for (final absence in absences) {
+      if (absence.id != null) {
+        await box.put(absence.id, absence);
+      }
+    }
     await box.close();
   }
 
+  /// Get all cached absences (unsorted)
   Future<List<AbsenceCacheModel>> getCachedAbsences() async {
     final box = await Hive.openBox<AbsenceCacheModel>(_boxName);
     final list = box.values.toList();

--- a/lib/data/services/local/member_local_service.dart
+++ b/lib/data/services/local/member_local_service.dart
@@ -4,13 +4,18 @@ import 'package:hive/hive.dart';
 class MemberLocalService {
   static const String _boxName = 'member_cache';
 
+  /// Save members by their userId as key to avoid duplication
   Future<void> saveMembers(List<MemberCacheModel> members) async {
     final box = await Hive.openBox<MemberCacheModel>(_boxName);
-    await box.clear();
-    await box.addAll(members);
+    for (final member in members) {
+      if (member.userId != null) {
+        await box.put(member.userId, member);
+      }
+    }
     await box.close();
   }
 
+  /// Get all cached members
   Future<List<MemberCacheModel>> getCachedMembers() async {
     final box = await Hive.openBox<MemberCacheModel>(_boxName);
     final list = box.values.toList();


### PR DESCRIPTION
## 🐛 Summary

This PR fixes a bug where:
- Only the last page of fetched absences was cached
- Cached data was duplicated when filters or pagination changed
- Offline filtering and pagination were not supported