### PR TITLE
use Google for connectivity check and add unit tests

### DIFF
--- a/lib/core/network/network_checker.dart
+++ b/lib/core/network/network_checker.dart
@@ -1,16 +1,13 @@
-import 'package:absence_manager/config/api_config.dart';
 import 'package:http/http.dart' as http;
 
-/// A utility class that verifies actual internet connectivity by making
-/// a lightweight HTTP request to the configured backend base URL.
 class NetworkChecker {
-  /// Returns `true` if the device can successfully reach the backend URL
-  /// within a short timeout (1200ms). Otherwise, returns `false`.
+  final String testUrl;
+
+  NetworkChecker({this.testUrl = 'https://www.google.com'});
+
   Future<bool> get hasConnection async {
     try {
-      final response = await http
-          .get(Uri.parse(ApiConfig.baseUrl))
-          .timeout(const Duration(milliseconds: 1200));
+      final response = await http.get(Uri.parse(testUrl)).timeout(const Duration(seconds: 5));
       return response.statusCode == 200;
     } catch (_) {
       return false;

--- a/test/data/repositories/absence/absence_repository_impl_test.mocks.dart
+++ b/test/data/repositories/absence/absence_repository_impl_test.mocks.dart
@@ -15,6 +15,7 @@ import 'package:absence_manager/data/services/local/absence_local_service.dart'
 import 'package:absence_manager/data/services/local/model/absence/absence_cache_model.dart'
     as _i6;
 import 'package:mockito/mockito.dart' as _i1;
+import 'package:mockito/src/dummies.dart' as _i8;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -99,6 +100,17 @@ class MockNetworkChecker extends _i1.Mock implements _i7.NetworkChecker {
   MockNetworkChecker() {
     _i1.throwOnMissingStub(this);
   }
+
+  @override
+  String get testUrl =>
+      (super.noSuchMethod(
+            Invocation.getter(#testUrl),
+            returnValue: _i8.dummyValue<String>(
+              this,
+              Invocation.getter(#testUrl),
+            ),
+          )
+          as String);
 
   @override
   _i3.Future<bool> get hasConnection =>

--- a/test/data/repositories/member/member_repository_impl_test.mocks.dart
+++ b/test/data/repositories/member/member_repository_impl_test.mocks.dart
@@ -15,6 +15,7 @@ import 'package:absence_manager/data/services/local/member_local_service.dart'
 import 'package:absence_manager/data/services/local/model/member/member_cache_model.dart'
     as _i6;
 import 'package:mockito/mockito.dart' as _i1;
+import 'package:mockito/src/dummies.dart' as _i8;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -86,6 +87,17 @@ class MockNetworkChecker extends _i1.Mock implements _i7.NetworkChecker {
   MockNetworkChecker() {
     _i1.throwOnMissingStub(this);
   }
+
+  @override
+  String get testUrl =>
+      (super.noSuchMethod(
+            Invocation.getter(#testUrl),
+            returnValue: _i8.dummyValue<String>(
+              this,
+              Invocation.getter(#testUrl),
+            ),
+          )
+          as String);
 
   @override
   _i3.Future<bool> get hasConnection =>


### PR DESCRIPTION
## ✨ Enhancement: Use Google for Internet Connectivity Check

This PR updates the `NetworkChecker` class to use **https://www.google.com** instead of the backend base URL. This results in a faster and more reliable connectivity check.
