### PR TITLE
use CORS-safe endpoint for universal connectivity check

### DIFF
--- a/lib/core/network/network_checker.dart
+++ b/lib/core/network/network_checker.dart
@@ -1,9 +1,16 @@
 import 'package:http/http.dart' as http;
 
+/// A utility class that verifies actual internet connectivity by making
+/// a lightweight HTTP request to a CORS-safe public endpoint.
+///
+/// Defaults to https://httpstat.us/200, which returns a 200 OK response
+/// and is accessible from all platforms, including Flutter Web.
+///
+/// Returns `true` if the response status is 200 within 5 seconds.
 class NetworkChecker {
   final String testUrl;
 
-  NetworkChecker({this.testUrl = 'https://www.google.com'});
+  NetworkChecker({this.testUrl = 'https://httpstat.us/200'});
 
   Future<bool> get hasConnection async {
     try {


### PR DESCRIPTION
## 🌐 Enhancement: CORS-safe Network Check for All Platforms

This PR updates the `NetworkChecker` class to use **https://httpstat.us/200** as the default URL for verifying internet connectivity.
