### PR TITLE
Split main.dart and add AppInfoCubit with version dialog

### DIFF
--- a/lib/absence_manager_app.dart
+++ b/lib/absence_manager_app.dart
@@ -1,0 +1,22 @@
+import 'package:absence_manager/config/service_locator.dart';
+import 'package:absence_manager/ui/absence/bloc/absence_bloc.dart';
+import 'package:absence_manager/ui/absence/bloc/absence_event.dart';
+import 'package:absence_manager/ui/absence/widgets/absence_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class AbsenceManagerApp extends StatelessWidget {
+  const AbsenceManagerApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Absence Manager',
+      theme: ThemeData(colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple)),
+      home: BlocProvider(
+        create: (_) => sl<AbsencesBloc>()..add(LoadAbsences()),
+        child: const AbsencesScreen(),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,37 +1,21 @@
+import 'package:absence_manager/absence_manager_app.dart';
 import 'package:absence_manager/config/service_locator.dart';
 import 'package:absence_manager/data/services/local/model/absence/absence_cache_model.dart';
 import 'package:absence_manager/data/services/local/model/member/member_cache_model.dart';
-import 'package:absence_manager/ui/absence/bloc/absence_bloc.dart';
-import 'package:absence_manager/ui/absence/bloc/absence_event.dart';
-import 'package:absence_manager/ui/absence/widgets/absence_screen.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  await Hive.initFlutter();
-  Hive.registerAdapter(AbsenceCacheModelAdapter());
-  Hive.registerAdapter(MemberCacheModelAdapter());
-
+  await _initHive();
   await setupLocator();
 
   runApp(const AbsenceManagerApp());
 }
 
-class AbsenceManagerApp extends StatelessWidget {
-  const AbsenceManagerApp({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Absence Manager',
-      theme: ThemeData(colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple)),
-      home: BlocProvider(
-        create: (_) => sl<AbsencesBloc>()..add(LoadAbsences()),
-        child: const AbsencesScreen(),
-      ),
-    );
-  }
+Future<void> _initHive() async {
+  await Hive.initFlutter();
+  Hive.registerAdapter(AbsenceCacheModelAdapter());
+  Hive.registerAdapter(MemberCacheModelAdapter());
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: absence_manager
 description: "A Flutter application to manage and display employee absences."
 
 publish_to: 'none'
-version: 1.0.0+1
+version: 1.3.2+1
 
 environment:
   sdk: ^3.7.2


### PR DESCRIPTION
### Additional Changes
- Split `main.dart` to improve structure and readability:
  - Moved app initialization logic (`Hive`, `setupLocator`, etc.) into `main.dart`
  - Moved widget tree and `MaterialApp` into a new `absence_manager_app.dart` file
- Bumped app version in `pubspec.yaml` to `1.3.2+1`